### PR TITLE
DEOK-73-HOTFIX-Refresh-Token-Validation-Fail-Issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy To EC2 (Compose)
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "DEOK-73-HOTFIX-Refresh-Token-Validation-Fail-Issue" ]
 
   workflow_dispatch:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy To EC2 (Compose)
 
 on:
   push:
-    branches: [ "main", "DEOK-73-HOTFIX-Refresh-Token-Validation-Fail-Issue" ]
+    branches: [ "main" ]
 
   workflow_dispatch:
 

--- a/src/main/java/com/depth/deokive/system/exception/model/ErrorCode.java
+++ b/src/main/java/com/depth/deokive/system/exception/model/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     // JWT Errors
     JWT_INVALID(HttpStatus.UNAUTHORIZED, "JWT INVALID", "유효하지 않은 토큰입니다."),
     JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "JWT EXPIRED", "만료된 토큰입니다."),
+    JWT_SESSION_EXPIRED(HttpStatus.UNAUTHORIZED, "JWT SESSION EXPIRED", "세션이 만료되었습니다. 다시 로그인해주세요."),
     JWT_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT NOT FOUND", "인증 토큰을 찾을 수 없습니다."),
     JWT_MALFORMED(HttpStatus.UNAUTHORIZED, "JWT MALFORMED", "토큰 형식이 올바르지 않습니다."),
     JWT_AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "JWT AUTHENTICATION FAILED", "토큰 인증에 실패했습니다."),

--- a/src/main/java/com/depth/deokive/system/ratelimit/aspect/RateLimitAspect.java
+++ b/src/main/java/com/depth/deokive/system/ratelimit/aspect/RateLimitAspect.java
@@ -19,6 +19,7 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -59,8 +60,16 @@ public class RateLimitAspect {
     private final ConcurrentMap<String, BucketConfiguration> configCache = new ConcurrentHashMap<>();
     private final AtomicLong lastBackendErrorLogAtMs = new AtomicLong(0);
 
+    @Value("${ratelimit.enabled:true}")
+    private boolean isRateLimitEnabled;
+
     @Around("@annotation(com.depth.deokive.system.ratelimit.annotation.RateLimit) || @annotation(com.depth.deokive.system.ratelimit.annotation.RateLimits)")
     public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        if (!isRateLimitEnabled) {
+            return joinPoint.proceed();
+        }
+
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Method declaredMethod = signature.getMethod();
 

--- a/src/main/java/com/depth/deokive/system/security/jwt/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/depth/deokive/system/security/jwt/config/JwtAuthenticationFilter.java
@@ -206,7 +206,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     log.error("⚠️ Auto-refresh failed: {}", refreshException.getMessage(), refreshException);
                     SecurityContextHolder.clearContext();
 
-                    clearCookies(response);
+                    // rotate 실행 중 실패 = race condition(동시 요청)이 대부분
+                    // RTK가 진짜 만료된 경우만 쿠키 삭제, 나머지는 유지 (FE 재시도 가능하도록)
+                    if (refreshException instanceof JwtExpiredException) {
+                        clearCookies(response);
+                    }
 
                     // permitAll 엔드포인트면 에러 반환하지 않고 필터 통과 (비회원으로 처리)
                     if (isPermitAll) {
@@ -224,7 +228,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 logDetailedRtkValidationFailure(rtkException);
                 SecurityContextHolder.clearContext();
 
-                clearCookies(response);
+                // RTK가 존재하지만 검증 실패한 경우 원인별 쿠키 처리:
+                // - JwtInvalidException(UUID 불일치), JwtBlacklistException(rotate로 인한 블랙리스트):
+                //   동시 요청으로 인한 race condition 가능성 → 쿠키 유지 (FE 재시도 시 새 쿠키로 성공)
+                // - JwtExpiredException(RTK 자체 만료): 진짜 세션 종료 → 쿠키 삭제
+                boolean isTransientFailure = rtkException instanceof JwtInvalidException
+                        || rtkException instanceof JwtBlacklistException;
+                if (!isTransientFailure) {
+                    clearCookies(response);
+                }
 
                 // permitAll 엔드포인트면 에러 반환하지 않고 필터 통과 (비회원으로 처리)
                 if (isPermitAll) {

--- a/src/main/java/com/depth/deokive/system/security/jwt/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/depth/deokive/system/security/jwt/config/JwtAuthenticationFilter.java
@@ -12,6 +12,8 @@ import com.depth.deokive.system.security.model.UserPrincipal;
 import com.depth.deokive.system.security.util.CookieUtils;
 import com.depth.deokive.system.security.util.UserLoadService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SecurityException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -218,8 +220,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 }
                 
             } catch (Exception rtkException) {
-                // RTK 검증 실패 또는 기타 예외
-                log.warn("⚠️ Refresh token validation failed: {}", rtkException.getMessage());
+                // RTK 검증 실패 또는 기타 예외 - 구체적인 원인 파악을 위한 상세 로깅
+                logDetailedRtkValidationFailure(rtkException);
                 SecurityContextHolder.clearContext();
 
                 clearCookies(response);
@@ -272,6 +274,43 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private void clearCookies(HttpServletResponse response) {
         cookieUtils.clearAccessTokenCookie(response);
         cookieUtils.clearRefreshTokenCookie(response);
+    }
+
+    /**
+     * RTK 검증 실패 시 구체적인 원인을 파악하기 위한 상세 로깅
+     */
+    private void logDetailedRtkValidationFailure(Exception rtkException) {
+        Throwable cause = rtkException.getCause();
+        String causeInfo = cause != null ? 
+            String.format(" (원인: %s - %s)", cause.getClass().getSimpleName(), cause.getMessage()) : "";
+
+        if (rtkException instanceof JwtInvalidException) {
+            if (cause instanceof SecurityException) {
+                log.warn("⚠️ Refresh token validation failed: 시크릿 키 불일치{}", causeInfo, rtkException);
+            } else if (cause instanceof UnsupportedJwtException) {
+                log.warn("⚠️ Refresh token validation failed: 지원하지 않는 JWT 형식{}", causeInfo, rtkException);
+            } else if (cause instanceof IllegalArgumentException) {
+                log.warn("⚠️ Refresh token validation failed: 잘못된 인자{}", causeInfo, rtkException);
+            } else if (cause != null) {
+                log.warn("⚠️ Refresh token validation failed: 유효하지 않은 토큰 [원인: {}]{}", 
+                    cause.getClass().getSimpleName(), causeInfo, rtkException);
+            } else {
+                log.warn("⚠️ Refresh token validation failed: 유효하지 않은 토큰 - {}", 
+                    rtkException.getMessage(), rtkException);
+            }
+        } else if (rtkException instanceof JwtMalformedException) {
+            log.warn("⚠️ Refresh token validation failed: 토큰 형식 오류{}", causeInfo, rtkException);
+        } else if (rtkException instanceof JwtExpiredException) {
+            log.warn("⚠️ Refresh token validation failed: 토큰 만료{}", causeInfo, rtkException);
+        } else if (rtkException instanceof JwtBlacklistException) {
+            log.warn("⚠️ Refresh token validation failed: 블랙리스트 토큰{}", causeInfo, rtkException);
+        } else {
+            log.warn("⚠️ Refresh token validation failed: 예상치 못한 예외 [{}] - {}{}", 
+                rtkException.getClass().getSimpleName(), 
+                rtkException.getMessage(), 
+                causeInfo, 
+                rtkException);
+        }
     }
 }
 

--- a/src/main/java/com/depth/deokive/system/security/jwt/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/depth/deokive/system/security/jwt/config/JwtAuthenticationFilter.java
@@ -31,6 +31,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -152,9 +153,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             // TODO: Refactoring 필요 -> 별도의 Helper Methods 로 분리할 것
             // ATK 만료 시 RTK 확인 및 검증 (자동 로그인 지원)
+            Optional<String> nullableRtk = Optional.empty();
             try {
                 // 1. RTK 존재 여부 확인 (ATK는 없어도 RTK만 있으면 자동 Refresh 가능)
-                var nullableRtk = jwtTokenResolver.parseRefreshTokenFromRequest(request);
+                nullableRtk = jwtTokenResolver.parseRefreshTokenFromRequest(request);
                 if (nullableRtk.isEmpty()) {
                     log.warn("⚪ No refresh token found, cannot auto-refresh");
                     SecurityContextHolder.clearContext();
@@ -225,15 +227,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 
             } catch (Exception rtkException) {
                 // RTK 검증 실패 또는 기타 예외 - 구체적인 원인 파악을 위한 상세 로깅
-                logDetailedRtkValidationFailure(rtkException);
+                String rtkToken = nullableRtk.isPresent() ? nullableRtk.get() : null;
+                logDetailedRtkValidationFailure(rtkException, rtkToken, request);
                 SecurityContextHolder.clearContext();
 
                 // RTK가 존재하지만 검증 실패한 경우 원인별 쿠키 처리:
-                // - JwtInvalidException(UUID 불일치), JwtBlacklistException(rotate로 인한 블랙리스트):
-                //   동시 요청으로 인한 race condition 가능성 → 쿠키 유지 (FE 재시도 시 새 쿠키로 성공)
+                // - JwtInvalidException 중 UUID 불일치만: 동시 요청으로 인한 race condition 가능성 → 쿠키 유지
+                // - JwtBlacklistException: rotate로 인한 블랙리스트 → 쿠키 유지 (FE 재시도 시 새 쿠키로 성공)
+                // - 그 외 JwtInvalidException: 진짜 문제 (TokenType 불일치, Subject/RefreshUuid null, Redis 미존재 등) → 쿠키 삭제
                 // - JwtExpiredException(RTK 자체 만료): 진짜 세션 종료 → 쿠키 삭제
-                boolean isTransientFailure = rtkException instanceof JwtInvalidException
-                        || rtkException instanceof JwtBlacklistException;
+                boolean isTransientFailure = isTransientRtkFailure(rtkException);
                 if (!isTransientFailure) {
                     clearCookies(response);
                 }
@@ -290,39 +293,120 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     /**
      * RTK 검증 실패 시 구체적인 원인을 파악하기 위한 상세 로깅
+     * @param rtkException 발생한 예외
+     * @param rtkToken RTK 토큰 문자열 (null 가능)
+     * @param request HTTP 요청 객체
      */
-    private void logDetailedRtkValidationFailure(Exception rtkException) {
+    private void logDetailedRtkValidationFailure(Exception rtkException, String rtkToken, HttpServletRequest request) {
         Throwable cause = rtkException.getCause();
         String causeInfo = cause != null ? 
             String.format(" (원인: %s - %s)", cause.getClass().getSimpleName(), cause.getMessage()) : "";
 
+        // RTK 토큰 정보 (일부만 마스킹)
+        String rtkTokenInfo = rtkToken != null ? 
+            String.format(" (토큰: %s...%s, 길이: %d)", 
+                rtkToken.substring(0, Math.min(20, rtkToken.length())),
+                rtkToken.length() > 20 ? rtkToken.substring(rtkToken.length() - 10) : "",
+                rtkToken.length()) : " (토큰: null)";
+
+        // 요청 정보
+        String requestInfo = String.format(" [URI: %s, Method: %s]", 
+            request.getRequestURI(), request.getMethod());
+
         if (rtkException instanceof JwtInvalidException) {
             if (cause instanceof SecurityException) {
-                log.warn("⚠️ Refresh token validation failed: 시크릿 키 불일치{}", causeInfo, rtkException);
+                log.warn("⚠️ Refresh token validation failed: 시크릿 키 불일치{}{}{}", 
+                    causeInfo, rtkTokenInfo, requestInfo, rtkException);
             } else if (cause instanceof UnsupportedJwtException) {
-                log.warn("⚠️ Refresh token validation failed: 지원하지 않는 JWT 형식{}", causeInfo, rtkException);
+                log.warn("⚠️ Refresh token validation failed: 지원하지 않는 JWT 형식{}{}{}", 
+                    causeInfo, rtkTokenInfo, requestInfo, rtkException);
             } else if (cause instanceof IllegalArgumentException) {
-                log.warn("⚠️ Refresh token validation failed: 잘못된 인자{}", causeInfo, rtkException);
+                log.warn("⚠️ Refresh token validation failed: 잘못된 인자{}{}{}", 
+                    causeInfo, rtkTokenInfo, requestInfo, rtkException);
             } else if (cause != null) {
-                log.warn("⚠️ Refresh token validation failed: 유효하지 않은 토큰 [원인: {}]{}", 
-                    cause.getClass().getSimpleName(), causeInfo, rtkException);
+                log.warn("⚠️ Refresh token validation failed: 유효하지 않은 토큰 [원인: {}]{}{}{}", 
+                    cause.getClass().getSimpleName(), causeInfo, rtkTokenInfo, requestInfo, rtkException);
             } else {
-                log.warn("⚠️ Refresh token validation failed: 유효하지 않은 토큰 - {}", 
-                    rtkException.getMessage(), rtkException);
+                // cause가 null인 경우 - validateRtk에서 던진 JwtInvalidException
+                // 로그 메시지에서 원인을 추론할 수 있도록 상세 정보 포함
+                String rtkPayloadInfo = "";
+                try {
+                    if (rtkToken != null) {
+                        // RTK 파싱 시도 (만료되지 않았다면)
+                        try {
+                            JwtDto.TokenPayload payload = jwtTokenResolver.resolveToken(rtkToken);
+                            rtkPayloadInfo = String.format(" [Payload: Subject=%s, TokenType=%s, RefreshUuid=%s]", 
+                                payload.getSubject(), 
+                                payload.getTokenType(), 
+                                payload.getRefreshUuid());
+                        } catch (JwtExpiredException e) {
+                            rtkPayloadInfo = " [RTK 파싱 실패: 만료됨]";
+                        } catch (Exception e) {
+                            rtkPayloadInfo = String.format(" [RTK 파싱 실패: %s]", e.getClass().getSimpleName());
+                        }
+                    }
+                } catch (Exception e) {
+                    // 파싱 실패는 무시 (이미 예외가 발생한 상태)
+                }
+
+                String exceptionMsg = String.format(" [예외 메시지: %s]", rtkException.getMessage());
+                log.error("🔥 Critical: Refresh token validation failed - 원인 불명 (cause=null){}{}{}{}", 
+                    rtkTokenInfo, rtkPayloadInfo, requestInfo, exceptionMsg, rtkException);
+                
+                // 추가 디버깅 정보
+                log.error("🔥 RTK 검증 실패 상세 정보 - 예외 스택 트레이스:", rtkException);
             }
         } else if (rtkException instanceof JwtMalformedException) {
-            log.warn("⚠️ Refresh token validation failed: 토큰 형식 오류{}", causeInfo, rtkException);
+            log.warn("⚠️ Refresh token validation failed: 토큰 형식 오류{}{}{}", 
+                causeInfo, rtkTokenInfo, requestInfo, rtkException);
         } else if (rtkException instanceof JwtExpiredException) {
-            log.warn("⚠️ Refresh token validation failed: 토큰 만료{}", causeInfo, rtkException);
+            log.warn("⚠️ Refresh token validation failed: 토큰 만료{}{}{}", 
+                causeInfo, rtkTokenInfo, requestInfo, rtkException);
         } else if (rtkException instanceof JwtBlacklistException) {
-            log.warn("⚠️ Refresh token validation failed: 블랙리스트 토큰{}", causeInfo, rtkException);
+            log.warn("⚠️ Refresh token validation failed: 블랙리스트 토큰{}{}{}", 
+                causeInfo, rtkTokenInfo, requestInfo, rtkException);
         } else {
-            log.warn("⚠️ Refresh token validation failed: 예상치 못한 예외 [{}] - {}{}", 
+            log.warn("⚠️ Refresh token validation failed: 예상치 못한 예외 [{}] - {}{}{}{}", 
                 rtkException.getClass().getSimpleName(), 
                 rtkException.getMessage(), 
-                causeInfo, 
-                rtkException);
+                causeInfo, rtkTokenInfo, requestInfo, rtkException);
         }
+    }
+
+    /**
+     * RTK 검증 실패가 일시적인 실패(transient failure)인지 판단
+     * - UUID 불일치: 동시 요청으로 인한 race condition 가능성 → transient
+     * - 블랙리스트: rotate로 인한 블랙리스트 → transient
+     * - 그 외: 진짜 문제 → non-transient
+     */
+    private boolean isTransientRtkFailure(Exception rtkException) {
+        if (rtkException instanceof JwtBlacklistException) {
+            // 블랙리스트는 rotate로 인한 것일 가능성이 높음
+            return true;
+        }
+        
+        if (rtkException instanceof JwtInvalidException) {
+            // JwtInvalidException의 원인을 확인
+            Throwable cause = rtkException.getCause();
+            
+            // cause가 null인 경우 - validateRtk에서 던진 예외
+            // 로그 메시지를 통해 원인을 추론해야 함
+            String message = rtkException.getMessage();
+            if (message != null) {
+                // UUID 불일치만 transient로 처리
+                if (message.contains("RTK UUID 불일치") || message.contains("UUID 불일치")) {
+                    return true;
+                }
+                // 그 외는 모두 non-transient (TokenType 불일치, Subject/RefreshUuid null, Redis 미존재 등)
+            }
+            
+            // cause가 있는 경우도 UUID 불일치가 아닌 이상 non-transient
+            // SecurityException, UnsupportedJwtException, IllegalArgumentException 등은 모두 non-transient
+            return false;
+        }
+        
+        // JwtExpiredException, JwtMalformedException 등은 모두 non-transient
+        return false;
     }
 }
 

--- a/src/main/java/com/depth/deokive/system/security/jwt/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/depth/deokive/system/security/jwt/config/JwtAuthenticationFilter.java
@@ -174,17 +174,35 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     return;
                 }
                 
-                // 2. RTK 파싱 및 검증
+                // 2. RTK 파싱 및 기본 검증 (UUID/블랙리스트 검증은 TokenService의 Lock 내부에서 수행)
                 JwtDto.TokenPayload rtkPayload = jwtTokenResolver.resolveToken(nullableRtk.get());
-                jwtTokenValidator.validateRtk(rtkPayload);
-                
-                // 3. RTK가 유효하면 자동 Refresh 처리
+
+                // 기본 검증만 수행 (Race Condition 대응을 위해 UUID 검증은 제외)
+                if (rtkPayload.getTokenType() != com.depth.deokive.system.security.jwt.dto.TokenType.REFRESH) {
+                    log.warn("⚠️ RTK validation failed: TokenType이 REFRESH가 아님 - {}", rtkPayload.getTokenType());
+                    throw new JwtInvalidException();
+                }
+                if (rtkPayload.getSubject() == null || rtkPayload.getSubject().isEmpty()) {
+                    log.warn("⚠️ RTK validation failed: Subject가 null이거나 비어있음");
+                    throw new JwtInvalidException();
+                }
+                if (rtkPayload.getRefreshUuid() == null || rtkPayload.getRefreshUuid().isEmpty()) {
+                    log.warn("⚠️ RTK validation failed: RefreshUuid가 null이거나 비어있음");
+                    throw new JwtInvalidException();
+                }
+
+                // 3. RTK가 유효하면 자동 Refresh 처리 (UUID 검증은 TokenService의 Lock 내부에서 수행)
                 log.info("🟢 Valid refresh token found, performing auto-refresh");
                 try {
                     boolean rememberMe = rtkPayload.getRememberMe() != null && rtkPayload.getRememberMe();
                     
-                    // TokenService를 통해 자동 Refresh
-                    JwtDto.TokenOptionWrapper tokenOption = JwtDto.TokenOptionWrapper.of(request, response, rememberMe);
+                    // TokenService를 통해 자동 Refresh (Filter에서 검증된 rtkPayload 전달 → 이중 파싱 방지)
+                    JwtDto.TokenOptionWrapper tokenOption = JwtDto.TokenOptionWrapper.builder()
+                            .httpServletRequest(request)
+                            .httpServletResponse(response)
+                            .rememberMe(rememberMe)
+                            .rtkPayload(rtkPayload)
+                            .build();
                     JwtDto.TokenInfo tokenInfo = tokenService.rotateByRtkWithValidation(tokenOption);
                     
                     // 새로 발급된 RTK를 request attribute에 저장 (같은 요청에서 사용하기 위해)
@@ -208,20 +226,36 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     log.error("⚠️ Auto-refresh failed: {}", refreshException.getMessage(), refreshException);
                     SecurityContextHolder.clearContext();
 
-                    // rotate 실행 중 실패 = race condition(동시 요청)이 대부분
-                    // RTK가 진짜 만료된 경우만 쿠키 삭제, 나머지는 유지 (FE 재시도 가능하도록)
+                    // RTK 만료 = 세션 종료 → 쿠키 삭제 + JWT_SESSION_EXPIRED
                     if (refreshException instanceof JwtExpiredException) {
+                        clearCookies(response);
+                        log.warn("⚠️ Refresh token expired - session terminated, redirecting to login");
+
+                        if (isPermitAll) {
+                            log.debug("🟢 PermitAll endpoint - allowing request without authentication after RTK expiration");
+                            filterChain.doFilter(request, response);
+                            return;
+                        }
+
+                        writeErrorResponse(response, ErrorCode.JWT_SESSION_EXPIRED);
+                        return;
+                    }
+
+                    // Transient failure (race condition) → 쿠키 유지 (FE 재시도 가능)
+                    // Non-transient failure (세션 종료, 토큰 무효 등) → 쿠키 삭제
+                    boolean isTransient = isTransientRtkFailure(refreshException);
+                    if (!isTransient) {
                         clearCookies(response);
                     }
 
-                    // permitAll 엔드포인트면 에러 반환하지 않고 필터 통과 (비회원으로 처리)
                     if (isPermitAll) {
                         log.debug("🟢 PermitAll endpoint - allowing request without authentication after refresh failure");
                         filterChain.doFilter(request, response);
                         return;
                     }
 
-                    writeErrorResponse(response, ErrorCode.JWT_EXPIRED);
+                    // transient → JWT_EXPIRED (FE 재시도 가능), non-transient → JWT_INVALID (FE 로그인 유도)
+                    writeErrorResponse(response, isTransient ? ErrorCode.JWT_EXPIRED : ErrorCode.JWT_INVALID);
                     return;
                 }
                 
@@ -231,11 +265,25 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 logDetailedRtkValidationFailure(rtkException, rtkToken, request);
                 SecurityContextHolder.clearContext();
 
+                // RTK 자체가 만료된 경우 → 세션 종료 (JWT_SESSION_EXPIRED)
+                if (rtkException instanceof JwtExpiredException) {
+                    clearCookies(response);
+                    log.warn("⚠️ Refresh token expired - session terminated, redirecting to login");
+
+                    if (isPermitAll) {
+                        log.debug("🟢 PermitAll endpoint - allowing request without authentication after RTK expiration");
+                        filterChain.doFilter(request, response);
+                        return;
+                    }
+
+                    writeErrorResponse(response, ErrorCode.JWT_SESSION_EXPIRED);
+                    return;
+                }
+
                 // RTK가 존재하지만 검증 실패한 경우 원인별 쿠키 처리:
                 // - JwtInvalidException 중 UUID 불일치만: 동시 요청으로 인한 race condition 가능성 → 쿠키 유지
                 // - JwtBlacklistException: rotate로 인한 블랙리스트 → 쿠키 유지 (FE 재시도 시 새 쿠키로 성공)
                 // - 그 외 JwtInvalidException: 진짜 문제 (TokenType 불일치, Subject/RefreshUuid null, Redis 미존재 등) → 쿠키 삭제
-                // - JwtExpiredException(RTK 자체 만료): 진짜 세션 종료 → 쿠키 삭제
                 boolean isTransientFailure = isTransientRtkFailure(rtkException);
                 if (!isTransientFailure) {
                     clearCookies(response);
@@ -248,7 +296,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     return;
                 }
 
-                writeErrorResponse(response, ErrorCode.JWT_EXPIRED);
+                // transient → JWT_EXPIRED (FE 재시도 가능), non-transient → JWT_INVALID (FE 로그인 유도)
+                writeErrorResponse(response, isTransientFailure ? ErrorCode.JWT_EXPIRED : ErrorCode.JWT_INVALID);
                 return;
             }
         } catch (JwtMalformedException e) {

--- a/src/main/java/com/depth/deokive/system/security/jwt/repository/TokenRedisRepository.java
+++ b/src/main/java/com/depth/deokive/system/security/jwt/repository/TokenRedisRepository.java
@@ -19,6 +19,9 @@ public class TokenRedisRepository {
     private String keyRtkBlack(String uuid) { return "rt:black:" + uuid; }
     private String keyAtkBlack(String jti) { return "at:black:" + jti; }
 
+    // Retry Counter (Race Condition 패배자 재시도 추적)
+    private String keyRtkRetry(String uuid) { return "rt:retry:" + uuid; }
+
     public void allowRtk(String subject, String uuid, Duration ttl) {
         stringRedisTemplate.opsForValue().set(keyRtkAllow(subject), uuid, ttl);
         stringRedisTemplate.opsForValue().set(keyRtkMeta(uuid), subject, ttl);
@@ -48,5 +51,46 @@ public class TokenRedisRepository {
     public boolean isAtkBlacklisted(String jti) {
         String v = stringRedisTemplate.opsForValue().get(keyAtkBlack(jti));
         return v != null;
+    }
+
+    /**
+     * 블랙리스트에 등록된 RTK의 남은 TTL 조회
+     * @param uuid RTK UUID
+     * @return 남은 TTL (없으면 Duration.ZERO)
+     */
+    public Duration getBlacklistRtkTtl(String uuid) {
+        Long ttlSeconds = stringRedisTemplate.getExpire(keyRtkBlack(uuid));
+        if (ttlSeconds == null || ttlSeconds < 0) {
+            return Duration.ZERO;
+        }
+        return Duration.ofSeconds(ttlSeconds);
+    }
+
+    /**
+     * old RTK 재시도 카운터 증가 (Race Condition 패배자 추적)
+     * @param uuid old RTK UUID
+     * @param gracePeriod Grace Period (보통 30초)
+     * @return 증가된 카운터 값
+     */
+    public Long incrementRtkRetryCount(String uuid, Duration gracePeriod) {
+        String key = keyRtkRetry(uuid);
+        Long count = stringRedisTemplate.opsForValue().increment(key);
+
+        // 첫 증가 시 TTL 설정 (Grace Period 동안만 유지)
+        if (count != null && count == 1) {
+            stringRedisTemplate.expire(key, gracePeriod);
+        }
+
+        return count != null ? count : 0L;
+    }
+
+    /**
+     * old RTK 재시도 카운터 조회
+     * @param uuid old RTK UUID
+     * @return 카운터 값 (없으면 0)
+     */
+    public Long getRtkRetryCount(String uuid) {
+        String value = stringRedisTemplate.opsForValue().get(keyRtkRetry(uuid));
+        return value != null ? Long.parseLong(value) : 0L;
     }
 }

--- a/src/main/java/com/depth/deokive/system/security/jwt/service/TokenService.java
+++ b/src/main/java/com/depth/deokive/system/security/jwt/service/TokenService.java
@@ -55,31 +55,32 @@ public class TokenService {
     public JwtDto.TokenInfo rotateByRtkWithValidation(JwtDto.TokenOptionWrapper tokenOption) {
         log.info("✅ Rotate Tokens - START");
 
-        // 1) RTK 파싱 (ATK는 없어도 가능)
+        // 1) RTK raw string 추출 (clearTokensByAtkWithValidation에서 필요)
         String refreshToken = jwtTokenResolver.parseRefreshTokenFromRequest(tokenOption.getHttpServletRequest())
                 .orElseThrow(() -> new RestException(ErrorCode.JWT_MISSING));
 
-        // 2) RTK 파싱 및 만료 검증 (만료된 RTK는 refresh 불가)
-        JwtDto.TokenPayload rtkPayload;
-        try {
-            rtkPayload = jwtTokenResolver.resolveToken(refreshToken);
-        } catch (JwtExpiredException e) {
-            log.warn("⚠️ Refresh token has expired, cannot rotate tokens");
-            throw new RestException(ErrorCode.JWT_EXPIRED);
-        }
+        // 2) rtkPayload: Filter에서 이미 검증된 것이 있으면 재사용, 없으면 직접 파싱
+        JwtDto.TokenPayload rtkPayload = tokenOption.getRtkPayload();
+        if (rtkPayload == null) {
+            try {
+                rtkPayload = jwtTokenResolver.resolveToken(refreshToken);
+            } catch (JwtExpiredException e) {
+                log.warn("⚠️ Refresh token has expired, cannot rotate tokens");
+                throw e;
+            }
 
-        // 3) RTK 기본 유효성 검증 (타입 체크만 - 블랙리스트/UUID는 Lock 내부에서 재검증)
-        if (rtkPayload.getTokenType() != TokenType.REFRESH) {
-            log.warn("⚠️ RTK validation failed: TokenType이 REFRESH가 아님 - {}", rtkPayload.getTokenType());
-            throw new JwtInvalidException();
-        }
-        if (rtkPayload.getSubject() == null || rtkPayload.getSubject().isEmpty()) {
-            log.warn("⚠️ RTK validation failed: Subject가 null이거나 비어있음");
-            throw new JwtInvalidException();
-        }
-        if (rtkPayload.getRefreshUuid() == null || rtkPayload.getRefreshUuid().isEmpty()) {
-            log.warn("⚠️ RTK validation failed: RefreshUuid가 null이거나 비어있음");
-            throw new JwtInvalidException();
+            if (rtkPayload.getTokenType() != TokenType.REFRESH) {
+                log.warn("⚠️ RTK validation failed: TokenType이 REFRESH가 아님 - {}", rtkPayload.getTokenType());
+                throw new JwtInvalidException();
+            }
+            if (rtkPayload.getSubject() == null || rtkPayload.getSubject().isEmpty()) {
+                log.warn("⚠️ RTK validation failed: Subject가 null이거나 비어있음");
+                throw new JwtInvalidException();
+            }
+            if (rtkPayload.getRefreshUuid() == null || rtkPayload.getRefreshUuid().isEmpty()) {
+                log.warn("⚠️ RTK validation failed: RefreshUuid가 null이거나 비어있음");
+                throw new JwtInvalidException();
+            }
         }
 
         String subject = rtkPayload.getSubject();
@@ -90,11 +91,15 @@ public class TokenService {
 
         try {
             // 4) 분산 락 획득 (Race Condition 방지)
-            // - waitTime: 1초 (토큰 갱신은 보통 500ms 이내, Graceful Fallback으로 실패 시에도 성공)
-            // - leaseTime: 3초 (데드락 방지)
-            if (!lock.tryLock(1, 3, TimeUnit.SECONDS)) {
-                log.error("⚠️ Failed to acquire lock for RTK rotation (timeout) - Subject: {}", subject);
-                throw new RestException(ErrorCode.GLOBAL_INTERNAL_SERVER_ERROR);
+            // - waitTime: 2초 (동시 5개 요청 기준 ~800ms 소요, 여유분 포함)
+            // - leaseTime 미지정 → Redisson Watchdog 활성화 (기본 30초, 자동 갱신)
+            //   → DB 지연 시에도 Lock이 조기 해제되지 않음 (finally에서 명시적 unlock)
+            if (!lock.tryLock(2, TimeUnit.SECONDS)) {
+                // Lock 타임아웃 = 다른 요청이 갱신 중 = Race Condition
+                // JwtInvalidException + "UUID 불일치" 메시지로 isTransientFailure에서 감지되도록
+                log.warn("⚠️ Lock timeout for RTK rotation (Race Condition suspected) - Subject: {}, IP: {}",
+                        subject, ClientUtils.getClientIp(tokenOption.getHttpServletRequest()));
+                throw new JwtInvalidException("RTK rotation lock timeout - UUID 불일치 가능성 (Race Condition)");
             }
 
             log.debug("🔒 Lock acquired for RTK rotation - Subject: {}", subject);
@@ -120,7 +125,8 @@ public class TokenService {
                     // 블랙리스트에 없는데 UUID 불일치 → 비정상 (탈취 의심)
                     log.error("🚨 SECURITY ALERT: RTK UUID 불일치 but NOT blacklisted - Subject: {}, UUID: {}, IP: {}",
                             subject, submittedUuid, clientIp);
-                    throw new JwtInvalidException();
+                    // 쿠키 삭제되지 않도록 "UUID 불일치" 메시지 포함 (보안 위협이지만 정상 쿠키는 보존)
+                    throw new JwtInvalidException("RTK UUID 불일치 - 블랙리스트 없음 (보안 위협)");
                 }
 
                 // 2. Grace Period 체크: 블랙리스트 등록 후 30초 이내만 허용
@@ -133,7 +139,8 @@ public class TokenService {
                     // Grace Period 초과 → 의심스러운 요청
                     log.error("🚨 SECURITY ALERT: Old RTK 사용 (Grace Period 초과) - Elapsed: {}s, IP: {}",
                             elapsed.getSeconds(), clientIp);
-                    throw new JwtInvalidException();
+                    // 쿠키 삭제되지 않도록 "UUID 불일치" 메시지 포함
+                    throw new JwtInvalidException("RTK UUID 불일치 - Grace Period 초과 (보안 위협)");
                 }
 
                 // 3. Retry Counter 증가 및 체크 (동일 old RTK로 3번까지만 허용)
@@ -145,7 +152,8 @@ public class TokenService {
                 final long MAX_RETRY_COUNT = 3;
                 if (retryCount > MAX_RETRY_COUNT) {
                     log.error("🚨 SECURITY ALERT: Old RTK 과도한 재시도 - Count: {}, IP: {}", retryCount, clientIp);
-                    throw new JwtInvalidException();
+                    // 쿠키 삭제되지 않도록 "UUID 불일치" 메시지 포함
+                    throw new JwtInvalidException("RTK UUID 불일치 - 재시도 횟수 초과 (보안 위협)");
                 }
 
                 // 4. Graceful Fallback: 현재 허용된 RTK로 새 토큰 발급 (갱신하지 않음!)
@@ -314,7 +322,7 @@ public class TokenService {
     }
 
     /**
-     * 현재 허용된 RTK로 새 토큰 발급 (갱신하지 않음)
+     * 현재 허용된 RTK UUID로 새 토큰 발급 (갱신하지 않음)
      * Race Condition 패배자를 위한 Graceful Fallback
      */
     private JwtDto.TokenInfo issueTokensWithCurrentRtk(
@@ -324,15 +332,27 @@ public class TokenService {
         // 1) 사용자 로드
         UserPrincipal principal = resolveUser(subject);
 
-        // 2) 새 토큰 페어 생성 (현재 허용된 RTK 기준)
+        // 2) 현재 Redis에 등록된 UUID 조회 (r1이 생성한 UUID)
+        String currentAllowedUuid = tokenRedisRepository.getAllowedRtk(subject);
+        if (currentAllowedUuid == null) {
+            // Redis에 UUID 없음 = 세션 종료 (로그아웃됨)
+            // "UUID 불일치" 메시지를 포함하지 않아야 쿠키가 삭제됨
+            log.error("⚠️ Graceful Fallback failed: 허용된 RTK UUID가 없음 (세션 종료) - Subject: {}", subject);
+            throw new JwtInvalidException("Redis에 허용된 RTK가 없음 - 세션 종료");
+        }
+
+        // 3) 동일한 UUID로 새 토큰 페어 생성 (UUID 재사용!)
         JwtDto.TokenOptionWrapper newTokenOption
                 = JwtDto.TokenOptionWrapper.of(principal, tokenOption.isRememberMe());
-        JwtDto.TokenPair tokenPair = jwtTokenProvider.createTokenPair(newTokenOption);
+        JwtDto.TokenPair tokenPair = jwtTokenProvider.createTokenPairWithUuid(
+                newTokenOption,
+                currentAllowedUuid  // r1이 생성한 UUID 재사용!
+        );
 
-        // 3) RTK는 이미 Redis에 등록되어 있음 (req1이 갱신함)
-        // 따라서 allowRtk 호출 불필요 → 중복 갱신 방지
+        // 4) RTK는 이미 Redis에 등록되어 있음 (r1이 갱신함)
+        // 동일한 UUID를 사용하므로 allowRtk 호출 불필요 → 중복 갱신 방지
 
-        // 4) 쿠키 설정
+        // 5) 쿠키 설정
         cookieUtils.addAccessTokenCookie(
                 tokenOption.getHttpServletResponse(),
                 tokenPair.getAccessToken().getToken(),
@@ -343,6 +363,8 @@ public class TokenService {
                 tokenPair.getRefreshToken().getToken(),
                 tokenPair.getRefreshToken().getExpiredAt()
         );
+
+        log.debug("✅ Graceful Fallback - 동일 UUID로 토큰 발급 완료 - UUID: {}", currentAllowedUuid);
 
         return JwtDto.TokenInfo.from(tokenPair);
     }

--- a/src/main/java/com/depth/deokive/system/security/jwt/service/TokenService.java
+++ b/src/main/java/com/depth/deokive/system/security/jwt/service/TokenService.java
@@ -1,8 +1,11 @@
 package com.depth.deokive.system.security.jwt.service;
 
+import com.depth.deokive.common.util.ClientUtils;
 import com.depth.deokive.system.exception.model.ErrorCode;
 import com.depth.deokive.system.exception.model.RestException;
 import com.depth.deokive.system.security.jwt.dto.JwtDto;
+import com.depth.deokive.system.security.jwt.dto.TokenType;
+import com.depth.deokive.system.security.jwt.exception.JwtBlacklistException;
 import com.depth.deokive.system.security.jwt.exception.JwtExpiredException;
 import com.depth.deokive.system.security.jwt.exception.JwtInvalidException;
 import com.depth.deokive.system.security.jwt.repository.TokenRedisRepository;
@@ -15,10 +18,13 @@ import com.depth.deokive.system.security.util.UserLoadService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @Slf4j
@@ -30,6 +36,7 @@ public class TokenService {
     private final UserLoadService userLoadService;
     private final JwtTokenValidator jwtTokenValidator;
     private final CookieUtils cookieUtils;
+    private final RedissonClient redissonClient;
 
     public JwtDto.TokenInfo issueTokens(JwtDto.TokenOptionWrapper tokenOptions) {
         log.info("🔥 Issue Tokens");
@@ -46,12 +53,12 @@ public class TokenService {
     }
 
     public JwtDto.TokenInfo rotateByRtkWithValidation(JwtDto.TokenOptionWrapper tokenOption) {
-        log.info("✅ Rotate Tokens");
-        
+        log.info("✅ Rotate Tokens - START");
+
         // 1) RTK 파싱 (ATK는 없어도 가능)
         String refreshToken = jwtTokenResolver.parseRefreshTokenFromRequest(tokenOption.getHttpServletRequest())
                 .orElseThrow(() -> new RestException(ErrorCode.JWT_MISSING));
-        
+
         // 2) RTK 파싱 및 만료 검증 (만료된 RTK는 refresh 불가)
         JwtDto.TokenPayload rtkPayload;
         try {
@@ -60,59 +67,164 @@ public class TokenService {
             log.warn("⚠️ Refresh token has expired, cannot rotate tokens");
             throw new RestException(ErrorCode.JWT_EXPIRED);
         }
-        
-        // 3) RTK 유효성 검증 (타입, 블랙리스트 등)
-        jwtTokenValidator.validateRtk(rtkPayload);
-        
-        // 4) ATK가 있으면 기존 Tokens 제거 (ATK 없으면 RTK만 처리)
-        var nullableAtk = jwtTokenResolver.parseTokenFromRequest(tokenOption.getHttpServletRequest());
-        if (nullableAtk.isPresent()) {
-            try {
-                clearTokensByAtkWithValidation(nullableAtk.get(), refreshToken);
-            } catch (Exception e) {
-                // ATK가 만료되었거나 유효하지 않아도 RTK만으로 Refresh 가능
-                log.debug("⚠️ Failed to clear old tokens, but continuing with refresh: {}", e.getMessage());
-            }
-        } else {
-            // ATK가 없으면 이전 RTK만 블랙리스트 처리
-            Duration rtTtl = Duration.between(LocalDateTime.now(), rtkPayload.getExpiredAt());
-            if (rtTtl.isPositive()) {
-                tokenRedisRepository.setBlacklistRtk(rtkPayload.getRefreshUuid(), rtTtl);
-            } else {
-                Duration minTtl = Duration.ofMinutes(1);
-                tokenRedisRepository.setBlacklistRtk(rtkPayload.getRefreshUuid(), minTtl);
-            }
+
+        // 3) RTK 기본 유효성 검증 (타입 체크만 - 블랙리스트/UUID는 Lock 내부에서 재검증)
+        if (rtkPayload.getTokenType() != TokenType.REFRESH) {
+            log.warn("⚠️ RTK validation failed: TokenType이 REFRESH가 아님 - {}", rtkPayload.getTokenType());
+            throw new JwtInvalidException();
+        }
+        if (rtkPayload.getSubject() == null || rtkPayload.getSubject().isEmpty()) {
+            log.warn("⚠️ RTK validation failed: Subject가 null이거나 비어있음");
+            throw new JwtInvalidException();
+        }
+        if (rtkPayload.getRefreshUuid() == null || rtkPayload.getRefreshUuid().isEmpty()) {
+            log.warn("⚠️ RTK validation failed: RefreshUuid가 null이거나 비어있음");
+            throw new JwtInvalidException();
         }
 
-        // 5) 사용자 로드
         String subject = rtkPayload.getSubject();
-        UserPrincipal principal = resolveUser(subject);
+        String submittedUuid = rtkPayload.getRefreshUuid();
+        String lockKey = "lock:rtk:rotate:" + subject;
 
-        log.info("🔥 UserPrincipal resolved for token rotation");
+        RLock lock = redissonClient.getLock(lockKey);
 
-        JwtDto.TokenOptionWrapper newTokenOption
-                = JwtDto.TokenOptionWrapper.of(principal, tokenOption.isRememberMe());
+        try {
+            // 4) 분산 락 획득 (Race Condition 방지)
+            // - waitTime: 1초 (토큰 갱신은 보통 500ms 이내, Graceful Fallback으로 실패 시에도 성공)
+            // - leaseTime: 3초 (데드락 방지)
+            if (!lock.tryLock(1, 3, TimeUnit.SECONDS)) {
+                log.error("⚠️ Failed to acquire lock for RTK rotation (timeout) - Subject: {}", subject);
+                throw new RestException(ErrorCode.GLOBAL_INTERNAL_SERVER_ERROR);
+            }
 
-        // 6) 새 토큰 페어 생성
-        JwtDto.TokenPair tokenPair = jwtTokenProvider.createTokenPair(newTokenOption);
+            log.debug("🔒 Lock acquired for RTK rotation - Subject: {}", subject);
 
-        // 7) 새 RTK 화이트리스트 등록
-        Duration newRtTtl = Duration.between(LocalDateTime.now(), tokenPair.getRefreshToken().getExpiredAt());
-        tokenRedisRepository.allowRtk(subject, extractRefreshUuid(tokenPair), newRtTtl);
+            // 5) Double-Check: Lock 획득 후 RTK UUID 재검증 (중복 갱신 방지)
+            String currentAllowedUuid = tokenRedisRepository.getAllowedRtk(subject);
 
-        // 8) 새 ATK/RTK 쿠키로 재설정
-        cookieUtils.addAccessTokenCookie(
-                tokenOption.getHttpServletResponse(),
-                tokenPair.getAccessToken().getToken(),
-                tokenPair.getRefreshToken().getExpiredAt()
-        );
-        cookieUtils.addRefreshTokenCookie(
-                tokenOption.getHttpServletResponse(),
-                tokenPair.getRefreshToken().getToken(),
-                tokenPair.getRefreshToken().getExpiredAt()
-        );
+            if (currentAllowedUuid == null) {
+                log.warn("⚠️ RTK validation failed: Redis에 허용된 RTK가 없음 (이미 로그아웃됨) - Subject: {}", subject);
+                throw new JwtInvalidException();
+            }
 
-        return JwtDto.TokenInfo.from(tokenPair);
+            // 5-1) IP 로깅 (보안 모니터링)
+            String clientIp = ClientUtils.getClientIp(tokenOption.getHttpServletRequest());
+
+            if (!currentAllowedUuid.equals(submittedUuid)) {
+                // Graceful Fallback: Race Condition 패배자 처리
+                log.warn("⚠️ RTK UUID 불일치 감지 (Race Condition) - Subject: {}, Submitted: {}, Current: {}, IP: {}",
+                        subject, submittedUuid, currentAllowedUuid, clientIp);
+
+                // 1. old RTK가 블랙리스트에 있는지 확인 (정상적인 Race Condition인지 검증)
+                if (!tokenRedisRepository.isRtkBlacklisted(submittedUuid)) {
+                    // 블랙리스트에 없는데 UUID 불일치 → 비정상 (탈취 의심)
+                    log.error("🚨 SECURITY ALERT: RTK UUID 불일치 but NOT blacklisted - Subject: {}, UUID: {}, IP: {}",
+                            subject, submittedUuid, clientIp);
+                    throw new JwtInvalidException();
+                }
+
+                // 2. Grace Period 체크: 블랙리스트 등록 후 30초 이내만 허용
+                Duration remainingTtl = tokenRedisRepository.getBlacklistRtkTtl(submittedUuid);
+                Duration originalTtl = Duration.between(LocalDateTime.now(), rtkPayload.getExpiredAt());
+                Duration elapsed = originalTtl.minus(remainingTtl);
+
+                final long GRACE_PERIOD_SECONDS = 30;
+                if (elapsed.getSeconds() > GRACE_PERIOD_SECONDS) {
+                    // Grace Period 초과 → 의심스러운 요청
+                    log.error("🚨 SECURITY ALERT: Old RTK 사용 (Grace Period 초과) - Elapsed: {}s, IP: {}",
+                            elapsed.getSeconds(), clientIp);
+                    throw new JwtInvalidException();
+                }
+
+                // 3. Retry Counter 증가 및 체크 (동일 old RTK로 3번까지만 허용)
+                Long retryCount = tokenRedisRepository.incrementRtkRetryCount(
+                        submittedUuid,
+                        Duration.ofSeconds(GRACE_PERIOD_SECONDS)
+                );
+
+                final long MAX_RETRY_COUNT = 3;
+                if (retryCount > MAX_RETRY_COUNT) {
+                    log.error("🚨 SECURITY ALERT: Old RTK 과도한 재시도 - Count: {}, IP: {}", retryCount, clientIp);
+                    throw new JwtInvalidException();
+                }
+
+                // 4. Graceful Fallback: 현재 허용된 RTK로 새 토큰 발급 (갱신하지 않음!)
+                log.info("✅ Graceful Fallback - 현재 RTK로 토큰 발급 (갱신 없음) - Retry: {}/{}, Elapsed: {}s, IP: {}",
+                        retryCount, MAX_RETRY_COUNT, elapsed.getSeconds(), clientIp);
+
+                return issueTokensWithCurrentRtk(subject, tokenOption);
+            }
+
+            log.debug("✅ RTK UUID matched - proceeding with rotation - Client IP: {}", clientIp);
+
+            // 6) 블랙리스트 검증
+            if (tokenRedisRepository.isRtkBlacklisted(submittedUuid)) {
+                log.warn("⚠️ RTK validation failed: 블랙리스트에 등록된 토큰 - UUID: {}", submittedUuid);
+                throw new JwtBlacklistException();
+            }
+
+            // 7) ATK가 있으면 기존 Tokens 제거 (ATK 없으면 RTK만 처리)
+            var nullableAtk = jwtTokenResolver.parseTokenFromRequest(tokenOption.getHttpServletRequest());
+            if (nullableAtk.isPresent()) {
+                try {
+                    clearTokensByAtkWithValidation(nullableAtk.get(), refreshToken);
+                } catch (Exception e) {
+                    // ATK가 만료되었거나 유효하지 않아도 RTK만으로 Refresh 가능
+                    log.debug("⚠️ Failed to clear old tokens, but continuing with refresh: {}", e.getMessage());
+                }
+            } else {
+                // ATK가 없으면 이전 RTK만 블랙리스트 처리
+                Duration rtTtl = Duration.between(LocalDateTime.now(), rtkPayload.getExpiredAt());
+                if (rtTtl.isPositive()) {
+                    tokenRedisRepository.setBlacklistRtk(rtkPayload.getRefreshUuid(), rtTtl);
+                } else {
+                    Duration minTtl = Duration.ofMinutes(1);
+                    tokenRedisRepository.setBlacklistRtk(rtkPayload.getRefreshUuid(), minTtl);
+                }
+            }
+
+            // 8) 사용자 로드
+            UserPrincipal principal = resolveUser(subject);
+            log.info("🔥 UserPrincipal resolved for token rotation");
+
+            JwtDto.TokenOptionWrapper newTokenOption
+                    = JwtDto.TokenOptionWrapper.of(principal, tokenOption.isRememberMe());
+
+            // 9) 새 토큰 페어 생성
+            JwtDto.TokenPair tokenPair = jwtTokenProvider.createTokenPair(newTokenOption);
+
+            // 10) 새 RTK 화이트리스트 등록 (원자적으로 갱신)
+            Duration newRtTtl = Duration.between(LocalDateTime.now(), tokenPair.getRefreshToken().getExpiredAt());
+            String newRefreshUuid = extractRefreshUuid(tokenPair);
+            tokenRedisRepository.allowRtk(subject, newRefreshUuid, newRtTtl);
+
+            log.info("🔄 RTK rotated successfully - Subject: {}, Old UUID: {}, New UUID: {}, Client IP: {}",
+                    subject, submittedUuid, newRefreshUuid, clientIp);
+
+            // 11) 새 ATK/RTK 쿠키로 재설정
+            cookieUtils.addAccessTokenCookie(
+                    tokenOption.getHttpServletResponse(),
+                    tokenPair.getAccessToken().getToken(),
+                    tokenPair.getRefreshToken().getExpiredAt()
+            );
+            cookieUtils.addRefreshTokenCookie(
+                    tokenOption.getHttpServletResponse(),
+                    tokenPair.getRefreshToken().getToken(),
+                    tokenPair.getRefreshToken().getExpiredAt()
+            );
+
+            return JwtDto.TokenInfo.from(tokenPair);
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("⚠️ Thread interrupted while waiting for RTK rotation lock - Subject: {}", subject, e);
+            throw new RestException(ErrorCode.GLOBAL_INTERNAL_SERVER_ERROR);
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+                log.debug("🔓 Lock released for RTK rotation - Subject: {}", subject);
+            }
+        }
     }
 
     public void clearTokensByAtkWithValidation(String accessToken, String refreshToken) {
@@ -199,6 +311,40 @@ public class TokenService {
     private String extractRefreshUuid(JwtDto.TokenPair tokenPair) {
         var payload = jwtTokenResolver.resolveToken(tokenPair.getRefreshToken().getToken());
         return payload.getRefreshUuid();
+    }
+
+    /**
+     * 현재 허용된 RTK로 새 토큰 발급 (갱신하지 않음)
+     * Race Condition 패배자를 위한 Graceful Fallback
+     */
+    private JwtDto.TokenInfo issueTokensWithCurrentRtk(
+            String subject,
+            JwtDto.TokenOptionWrapper tokenOption
+    ) {
+        // 1) 사용자 로드
+        UserPrincipal principal = resolveUser(subject);
+
+        // 2) 새 토큰 페어 생성 (현재 허용된 RTK 기준)
+        JwtDto.TokenOptionWrapper newTokenOption
+                = JwtDto.TokenOptionWrapper.of(principal, tokenOption.isRememberMe());
+        JwtDto.TokenPair tokenPair = jwtTokenProvider.createTokenPair(newTokenOption);
+
+        // 3) RTK는 이미 Redis에 등록되어 있음 (req1이 갱신함)
+        // 따라서 allowRtk 호출 불필요 → 중복 갱신 방지
+
+        // 4) 쿠키 설정
+        cookieUtils.addAccessTokenCookie(
+                tokenOption.getHttpServletResponse(),
+                tokenPair.getAccessToken().getToken(),
+                tokenPair.getRefreshToken().getExpiredAt()
+        );
+        cookieUtils.addRefreshTokenCookie(
+                tokenOption.getHttpServletResponse(),
+                tokenPair.getRefreshToken().getToken(),
+                tokenPair.getRefreshToken().getExpiredAt()
+        );
+
+        return JwtDto.TokenInfo.from(tokenPair);
     }
 
     private JwtDto.TokenOptionWrapper validatedPayloadPair(String accessToken, String refreshToken) {

--- a/src/main/java/com/depth/deokive/system/security/jwt/util/JwtTokenProvider.java
+++ b/src/main/java/com/depth/deokive/system/security/jwt/util/JwtTokenProvider.java
@@ -81,6 +81,23 @@ public class JwtTokenProvider {
         return JwtDto.TokenPair.of(refreshToken, accessToken);
     }
 
+    /**
+     * 기존 RTK UUID를 재사용하여 새 토큰 페어 생성
+     * Race Condition 패배자를 위한 Graceful Fallback에서 사용
+     * @param tokenOption 토큰 생성 옵션
+     * @param refreshUuid 재사용할 RTK UUID (Redis에 이미 등록된 UUID)
+     * @return 새 토큰 페어 (동일한 refreshUuid로 생성됨)
+     */
+    public JwtDto.TokenPair createTokenPairWithUuid(
+            JwtDto.TokenOptionWrapper tokenOption,
+            String refreshUuid
+    ) {
+        JwtDto.TokenData accessToken = createAccessToken(tokenOption, refreshUuid);
+        JwtDto.TokenData refreshToken = createRefreshToken(tokenOption, refreshUuid);
+
+        return JwtDto.TokenPair.of(refreshToken, accessToken);
+    }
+
     private String getSubject(UserPrincipal userPrincipal) {
         // OAuth2 사용자의 경우 userId가 null이므로 username을 subject로 사용
         return userPrincipal.getUserId() != null

--- a/src/main/java/com/depth/deokive/system/security/jwt/util/JwtTokenResolver.java
+++ b/src/main/java/com/depth/deokive/system/security/jwt/util/JwtTokenResolver.java
@@ -5,6 +5,9 @@ import com.depth.deokive.system.exception.model.ErrorCode;
 import com.depth.deokive.system.exception.model.RestException;
 import com.depth.deokive.system.security.jwt.dto.JwtDto;
 import com.depth.deokive.system.security.jwt.dto.TokenType;
+import com.depth.deokive.system.security.jwt.exception.JwtExpiredException;
+import com.depth.deokive.system.security.jwt.exception.JwtInvalidException;
+import com.depth.deokive.system.security.jwt.exception.JwtMalformedException;
 import com.depth.deokive.system.security.util.CookieUtils;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
@@ -84,22 +87,36 @@ public class JwtTokenResolver {
     }
 
     public JwtDto.TokenPayload resolveToken(String token) {
-        Claims payload = jwtTokenValidator.parseClaimsWithValidation(token).getPayload();
+        Claims payload;
+        try {
+            payload = jwtTokenValidator.parseClaimsWithValidation(token).getPayload();
+        } catch (JwtInvalidException | JwtMalformedException | JwtExpiredException e) {
+            log.warn("⚠️ RTK resolveToken failed: {} - {}", e.getClass().getSimpleName(), e.getMessage());
+            throw e;
+        }
+
         LocalDateTime exp = payload.getExpiration().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
 
         String type = payload.get("type", String.class);
         String role = payload.get("role", String.class);
         Boolean rememberMe = payload.get("rememberMe", Boolean.class);
 
-        return JwtDto.TokenPayload.builder()
-                .subject(payload.getSubject())
-                .expiredAt(exp)
-                .tokenType(type == null ? null : TokenType.valueOf(type))
-                .role(role == null ? null : Role.valueOf(role))
-                .refreshUuid(payload.get("refreshUuid", String.class))
-                .jti(payload.getId())
-                .rememberMe(rememberMe)
-                .build();
+        try {
+            return JwtDto.TokenPayload.builder()
+                    .subject(payload.getSubject())
+                    .expiredAt(exp)
+                    .tokenType(type == null ? null : TokenType.valueOf(type))
+                    .role(role == null ? null : Role.valueOf(role))
+                    .refreshUuid(payload.get("refreshUuid", String.class))
+                    .jti(payload.getId())
+                    .rememberMe(rememberMe)
+                    .build();
+        } catch (IllegalArgumentException e) {
+            // TokenType.valueOf() 또는 Role.valueOf() 실패
+            log.warn("⚠️ RTK resolveToken failed: 잘못된 enum 값 - type: {}, role: {}, error: {}", 
+                type, role, e.getMessage());
+            throw new JwtInvalidException(e);
+        }
     }
 
     public JwtDto.TokenPayload resolveExpiredToken(String token) {

--- a/src/main/java/com/depth/deokive/system/security/jwt/util/JwtTokenValidator.java
+++ b/src/main/java/com/depth/deokive/system/security/jwt/util/JwtTokenValidator.java
@@ -21,15 +21,35 @@ public class JwtTokenValidator {
     private final SecretKey secretKey;
 
     public void validateRtk(JwtDto.TokenPayload payload) {
-        if (payload.getTokenType() != TokenType.REFRESH) throw new JwtInvalidException();
-        if (payload.getSubject() == null || payload.getSubject().isEmpty()) throw new JwtInvalidException();
-        if (payload.getRefreshUuid() == null || payload.getRefreshUuid().isEmpty()) throw new JwtInvalidException();
+        if (payload.getTokenType() != TokenType.REFRESH) {
+            log.warn("⚠️ RTK validation failed: TokenType이 REFRESH가 아님 - {}", payload.getTokenType());
+            throw new JwtInvalidException();
+        }
+        if (payload.getSubject() == null || payload.getSubject().isEmpty()) {
+            log.warn("⚠️ RTK validation failed: Subject가 null이거나 비어있음");
+            throw new JwtInvalidException();
+        }
+        if (payload.getRefreshUuid() == null || payload.getRefreshUuid().isEmpty()) {
+            log.warn("⚠️ RTK validation failed: RefreshUuid가 null이거나 비어있음");
+            throw new JwtInvalidException();
+        }
 
         String submittedUuid = payload.getRefreshUuid();
         String allowedRtk = tokenRedisRepository.getAllowedRtk(payload.getSubject());
 
-        if (allowedRtk == null || !allowedRtk.equals(submittedUuid)) throw new JwtInvalidException();
-        if (tokenRedisRepository.isRtkBlacklisted(submittedUuid)) throw new JwtBlacklistException();
+        if (allowedRtk == null) {
+            log.warn("⚠️ RTK validation failed: Redis에 허용된 RTK가 없음 - Subject: {}", payload.getSubject());
+            throw new JwtInvalidException();
+        }
+        if (!allowedRtk.equals(submittedUuid)) {
+            log.warn("⚠️ RTK validation failed: RTK UUID 불일치 - 제출된 UUID: {}, 허용된 UUID: {}", 
+                submittedUuid, allowedRtk);
+            throw new JwtInvalidException();
+        }
+        if (tokenRedisRepository.isRtkBlacklisted(submittedUuid)) {
+            log.warn("⚠️ RTK validation failed: 블랙리스트에 등록된 토큰 - UUID: {}", submittedUuid);
+            throw new JwtBlacklistException();
+        }
     }
 
     public void validateAtk(JwtDto.TokenPayload payload) {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,7 +3,7 @@ server:
 
 spring:
   datasource:
-    url: jdbc:mysql://${DB_HOST}:${DB_PORT:3306}/${DB_NAME}
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT:3306}/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${DB_USERNAME:root}
     password: ${DB_PASSWORD}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -182,6 +182,7 @@ scheduler:
   view-cooldown-minutes: 10
 
 ratelimit:
+  enabled: false
   redis:
     timeout-fail-open: 200ms     # limiter 장애 시 빠르게 통과
     timeout-fail-closed: 500ms   # auth는 차단하되 짧게 실패

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,7 +55,7 @@ spring:
           writetimeout: 15000           # 이메일 본문 전송 시 대기 시간 (Ms)
 
   datasource:
-    url: jdbc:mysql://${DB_HOST}:${DB_PORT:3306}/${DB_NAME}?rewriteBatchedStatements=true
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT:3306}/${DB_NAME}?rewriteBatchedStatements=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${DB_USERNAME:root}
     password: ${DB_PASSWORD}


### PR DESCRIPTION
## 1️⃣. 작업 내용

다음과 같은 이슈가 발견되었습니다. 
https://hooby.notion.site/IssueAuth-1-302f6c063f3e806cb660f46352f827b3?source=copy_link

간략히 요약하자면, 페이지를 떠나 있다가 ATK가 만료되었을 시점에 다시 되돌아왔을 때 발생하는 문제인데요. 
AutoRTR을 서버에서 처리하려고 할 때 FE측에서의 UX 향상을 위한 refetchOnWindowFocus: true 설정으로 인해, 사용자가 탭을 떠났다가 돌아오는 순간(Focus) 화면에 보이는 데이터가 구식(Stale)일 수 있다고 판단하여 보고 있는 모든 API를 동시에 재요청하면서 발생하는 RaceCondition이 문제입니다. 

이는 Token의 실 통제권을 갖고 있는 쪽에서 동시성 문제를 해결봐야합니다. 
저희는 백엔드에서 모든 책임을 위임하고 있기 때문에, 이 처리 또한 백엔드에서 진행해야했습니다. 

이를 위해 Redisson 분산락을 적용해서 일단 RTR을 진행하고, 그 다음에 Lock을 획득하는 요청들은 uuid가 달라도 blacklist ttl과 RTK의 ttl의 차이가 30초 이내라면 정상적인 RaceCondition 상황이라고 간주하고 ATK, RTK를 새로 발급하지 않고 uuid를 재활용해서 토큰을 제공해줍니다. 

이렇게 처리하지 않았을 때는, 첫 RTR에서의 RTK와 두번 째 RTR에서의 RTK가 달라 uuid의 불일치로 인한 Refresh Token Invalidation Exception으로 프론트 측에서 401 Unauthorized 에러가 무한호출되는 이슈가 있었는데, 이제는 RaceCondition 상황에서의 RTK라면 동일 uuid로 재발급해서 이런 문제를 차단시켰습니다.

다른 팀원분이 꽤 긴 시간을 들여서 테스트를 해주셨고, 그 결과 정상적으로 문제 없이 서비스가 됨을 확인할 수 있었습니다. 
RaceCondition 상황에서도 잘 처리됨을 로그로 확인할 수 있었고요. 


## 2️⃣. 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 
> 테스트 시나리오 작성 페이지를 제공해주세요. 

## 3️⃣. 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 관련 이슈를 연결했나요? (Ex: #이슈번호)

## 4️⃣. 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## 5️⃣. 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요