### PR TITLE
DEOK-74-Deep-Pagination-Count-Query-Caching

### DIFF
--- a/src/main/java/com/depth/deokive/common/service/LikeMessagePublisher.java
+++ b/src/main/java/com/depth/deokive/common/service/LikeMessagePublisher.java
@@ -1,0 +1,24 @@
+package com.depth.deokive.common.service;
+
+import com.depth.deokive.common.dto.LikeMessageDto;
+import com.depth.deokive.common.enums.ViewLikeDomain;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LikeMessagePublisher {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    @Async("messagingTaskExecutor")
+    public void sendToQueue(ViewLikeDomain domain, Long targetId, Long userId, boolean isLiked) {
+        LikeMessageDto message = new LikeMessageDto(targetId, userId, isLiked);
+        rabbitTemplate.convertAndSend(domain.getExchangeName(), domain.getRoutingKey(), message);
+        log.info("🐇 [MQ Send] Domain: {}, TargetId: {}, Action: {}", domain, targetId, isLiked ? "LIKE" : "UNLIKE");
+    }
+}

--- a/src/main/java/com/depth/deokive/common/service/LikeRedisService.java
+++ b/src/main/java/com/depth/deokive/common/service/LikeRedisService.java
@@ -1,6 +1,5 @@
 package com.depth.deokive.common.service;
 
-import com.depth.deokive.common.dto.LikeMessageDto;
 import com.depth.deokive.common.enums.ViewLikeDomain;
 import com.depth.deokive.system.exception.model.ErrorCode;
 import com.depth.deokive.system.exception.model.RestException;
@@ -8,10 +7,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -24,9 +21,9 @@ import java.util.function.Supplier;
 public class LikeRedisService {
 
     private final RedisTemplate<String, Long> longRedisTemplate;
-    private final RabbitTemplate rabbitTemplate;
     private final RedissonClient redissonClient;
     private final DefaultRedisScript<Long> likeScript;
+    private final LikeMessagePublisher likeMessagePublisher;
 
     private static final String DUMMY_VALUE = "dummy";
     private static final String TTL_SECONDS = "259200"; // 3일
@@ -64,8 +61,8 @@ public class LikeRedisService {
 
         boolean isLiked = (result != null && result == 1);
 
-        // 3. MQ 전송
-        sendToQueue(domain, targetId, userId, isLiked);
+        // 3. MQ 비동기 전송 (별도 Bean 호출로 @Async 프록시 정상 동작)
+        likeMessagePublisher.sendToQueue(domain, targetId, userId, isLiked);
 
         return isLiked;
     }
@@ -128,13 +125,6 @@ public class LikeRedisService {
                 lock.unlock();
             }
         }
-    }
-
-    @Async("messagingTaskExecutor")
-    public void sendToQueue(ViewLikeDomain domain, Long targetId, Long userId, boolean isLiked) {
-        LikeMessageDto message = new LikeMessageDto(targetId, userId, isLiked);
-        rabbitTemplate.convertAndSend(domain.getExchangeName(), domain.getRoutingKey(), message);
-        log.info("🐇 [MQ Send] Domain: {}, TargetId: {}, Action: {}", domain, targetId, isLiked ? "LIKE" : "UNLIKE");
     }
 
     public void deleteLikeData(ViewLikeDomain domain, Long targetId) {

--- a/src/main/java/com/depth/deokive/common/service/PaginationCountCacheService.java
+++ b/src/main/java/com/depth/deokive/common/service/PaginationCountCacheService.java
@@ -1,0 +1,92 @@
+package com.depth.deokive.common.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * 페이지네이션 COUNT 쿼리 캐싱 서비스 (Redis)
+ *
+ * <p>Deep Pagination에서 매 요청마다 실행되는 COUNT 쿼리를 Redis에 캐싱하여
+ * 동시 요청 시 DB 부하를 제거한다.</p>
+ *
+ * <p>Redis 기반이므로 수평 확장(서버 증설) 시에도 모든 인스턴스가
+ * 동일한 캐시를 공유한다.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaginationCountCacheService {
+
+    private final RedisTemplate<String, Long> longRedisTemplate;
+
+    private static final String KEY_PREFIX = "pagination:count:";
+    private static final Duration TTL = Duration.ofSeconds(60);
+
+    /**
+     * 캐시된 COUNT 값을 반환한다. (Cache-Aside 패턴)
+     * - Cache Hit: Redis 값 반환
+     * - Cache Miss: countSupplier 실행 후 Redis에 저장
+     *
+     * @param cacheKey      캐시 키 (예: "post:feed:ALL", "archive:global:PUBLIC")
+     * @param countSupplier COUNT 쿼리 실행 Supplier (Cache Miss 시에만 호출)
+     */
+    public long getCount(String cacheKey, Supplier<Long> countSupplier) {
+        String key = KEY_PREFIX + cacheKey;
+
+        try {
+            Object cached = longRedisTemplate.opsForValue().get(key);
+            if (cached != null) {
+                return Long.parseLong(cached.toString());
+            }
+
+            long count = countSupplier.get();
+            longRedisTemplate.opsForValue().set(key, count, TTL);
+            return count;
+        } catch (Exception e) {
+            log.warn("[Pagination Count] Redis error, falling back to direct query. key={}, error={}",
+                    key, e.getMessage());
+            return countSupplier.get();
+        }
+    }
+
+    /**
+     * 정확한 캐시 키를 삭제한다.
+     * 필터 조건이 고정된 도메인(Gallery, Repost, Ticket)에서 사용한다.
+     *
+     * @param cacheKey 캐시 키 (예: "gallery:456", "repost:789")
+     */
+    public void evict(String cacheKey) {
+        String key = KEY_PREFIX + cacheKey;
+        try {
+            longRedisTemplate.delete(key);
+        } catch (Exception e) {
+            log.warn("[Pagination Count] Cache eviction failed. key={}, error={}",
+                    key, e.getMessage());
+        }
+    }
+
+    /**
+     * 접두사 기반으로 관련 캐시를 일괄 삭제한다.
+     * 필터 조건 조합이 다양한 도메인(Post, Archive, Diary)에서 사용한다.
+     *
+     * @param prefix 캐시 키 접두사 (예: "post", "archive", "diary:123")
+     */
+    public void evictByPrefix(String prefix) {
+        String pattern = KEY_PREFIX + prefix + ":*";
+        try {
+            Set<String> keys = longRedisTemplate.keys(pattern);
+            if (keys != null && !keys.isEmpty()) {
+                longRedisTemplate.delete(keys);
+            }
+        } catch (Exception e) {
+            log.warn("[Pagination Count] Cache eviction failed. pattern={}, error={}",
+                    pattern, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/depth/deokive/common/service/PaginationIdCacheService.java
+++ b/src/main/java/com/depth/deokive/common/service/PaginationIdCacheService.java
@@ -1,0 +1,112 @@
+package com.depth.deokive.common.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * 페이지네이션 ID 리스트 캐싱 서비스 (Redis)
+ *
+ * <p>Deep Pagination에서 매 요청마다 실행되는 offset scan(커버링 인덱스 쿼리)의
+ * 결과(ID 리스트)를 Redis에 캐싱하여, 같은 필터+정렬+페이지 조합의
+ * 동시 요청에서 DB 부하를 제거한다.</p>
+ *
+ * <p>직렬화: {@code List<Long>} → 쉼표 구분 문자열 ({@code "10231,10230,10229"})</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaginationIdCacheService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    private static final String KEY_PREFIX = "pagination:ids:";
+    private static final Duration TTL = Duration.ofSeconds(60);
+
+    /**
+     * 캐시된 ID 리스트를 반환한다. (Cache-Aside 패턴)
+     * - Cache Hit: Redis 값 역직렬화 후 반환
+     * - Cache Miss: idsSupplier 실행 후 Redis에 저장
+     * - 빈 리스트는 캐싱하지 않음 (새 데이터 추가 시 즉시 반영)
+     *
+     * @param cacheKey    캐시 키 (예: "post:feed:ALL:createdAt_DESC,id_DESC:0:20")
+     * @param idsSupplier ID 조회 쿼리 실행 Supplier (Cache Miss 시에만 호출)
+     */
+    public List<Long> getIds(String cacheKey, Supplier<List<Long>> idsSupplier) {
+        String key = KEY_PREFIX + cacheKey;
+
+        try {
+            String cached = stringRedisTemplate.opsForValue().get(key);
+            if (cached != null) {
+                return deserialize(cached);
+            }
+
+            List<Long> ids = idsSupplier.get();
+
+            if (!ids.isEmpty()) {
+                stringRedisTemplate.opsForValue().set(key, serialize(ids), TTL);
+            }
+
+            return ids;
+        } catch (Exception e) {
+            log.warn("[Pagination IDs] Redis error, falling back to direct query. key={}, error={}",
+                    key, e.getMessage());
+            return idsSupplier.get();
+        }
+    }
+
+    /**
+     * 정확한 캐시 키를 삭제한다.
+     */
+    public void evict(String cacheKey) {
+        String key = KEY_PREFIX + cacheKey;
+        try {
+            stringRedisTemplate.delete(key);
+        } catch (Exception e) {
+            log.warn("[Pagination IDs] Cache eviction failed. key={}, error={}",
+                    key, e.getMessage());
+        }
+    }
+
+    /**
+     * 접두사 기반으로 관련 캐시를 일괄 삭제한다.
+     *
+     * @param prefix 캐시 키 접두사 (예: "post", "archive", "diary:123")
+     */
+    public void evictByPrefix(String prefix) {
+        String pattern = KEY_PREFIX + prefix + ":*";
+        try {
+            Set<String> keys = stringRedisTemplate.keys(pattern);
+            if (keys != null && !keys.isEmpty()) {
+                stringRedisTemplate.delete(keys);
+            }
+        } catch (Exception e) {
+            log.warn("[Pagination IDs] Cache eviction failed. pattern={}, error={}",
+                    pattern, e.getMessage());
+        }
+    }
+
+    private String serialize(List<Long> ids) {
+        return ids.stream()
+                .map(String::valueOf)
+                .collect(Collectors.joining(","));
+    }
+
+    private List<Long> deserialize(String value) {
+        if (value.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(value.split(","))
+                .map(Long::parseLong)
+                .toList();
+    }
+}

--- a/src/main/java/com/depth/deokive/domain/archive/repository/ArchiveQueryRepository.java
+++ b/src/main/java/com/depth/deokive/domain/archive/repository/ArchiveQueryRepository.java
@@ -1,6 +1,7 @@
 package com.depth.deokive.domain.archive.repository;
 
 import com.depth.deokive.common.service.PaginationCountCacheService;
+import com.depth.deokive.common.service.PaginationIdCacheService;
 import com.depth.deokive.domain.archive.dto.ArchiveDto;
 import com.depth.deokive.domain.archive.dto.QArchiveDto_ArchivePageResponse;
 import com.depth.deokive.common.enums.Visibility;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Repository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -31,6 +33,7 @@ public class ArchiveQueryRepository {
 
     private final JPAQueryFactory queryFactory;
     private final PaginationCountCacheService paginationCountCacheService;
+    private final PaginationIdCacheService paginationIdCacheService;
 
     public Page<ArchiveDto.ArchivePageResponse> searchArchiveFeed(
             Long filterUserId,
@@ -51,22 +54,32 @@ public class ArchiveQueryRepository {
                 .collect(Collectors.joining(","));
         String countCacheKey;
 
+        // 정렬 키 (ID 캐시용)
+        String sortKey = pageable.getSort().stream()
+                .map(o -> o.getProperty() + "_" + o.getDirection())
+                .collect(Collectors.joining(","));
+        String pageKey = ":" + (sortKey.isEmpty() ? "default" : sortKey)
+                + ":" + pageable.getPageNumber() + ":" + pageable.getPageSize();
+
         // STEP 2. 커버링 인덱스 활용 (ID만 조회) && 정렬 조건 분기 : My Archives vs Global Archives
         if (isOptimizedPath) {
             // Case 1. My Archives(Me or Friends) -> Archive Table Scan
             countCacheKey = "archive:opt:" + filterUserId + ":" + visKey;
+            String idsCacheKey = countCacheKey + pageKey;
 
-            ids = queryFactory
-                    .select(archive.id)
-                    .from(archive)
-                    .where(
-                            archive.user.id.eq(filterUserId),
-                            inVisibilitiesForArchive(allowedVisibilities) // Archive 엔티티 조건 사용
-                    )
-                    .orderBy(getArchiveOrderSpecifiers(pageable)) // Archive 컬럼 기준 정렬
-                    .offset(pageable.getOffset())
-                    .limit(pageable.getPageSize())
-                    .fetch();
+            ids = paginationIdCacheService.getIds(idsCacheKey, () ->
+                    queryFactory
+                            .select(archive.id)
+                            .from(archive)
+                            .where(
+                                    archive.user.id.eq(filterUserId),
+                                    inVisibilitiesForArchive(allowedVisibilities)
+                            )
+                            .orderBy(getArchiveOrderSpecifiers(pageable))
+                            .offset(pageable.getOffset())
+                            .limit(pageable.getPageSize())
+                            .fetch()
+            );
 
             countQuery = queryFactory
                     .select(archive.count())
@@ -78,24 +91,26 @@ public class ArchiveQueryRepository {
         } else {
             // Case 2. Global Archives -> ArchiveStats 기반 조회
             countCacheKey = "archive:global:" + (filterUserId != null ? filterUserId : "all") + ":" + visKey;
+            String idsCacheKey = countCacheKey + pageKey;
 
-            JPAQuery<Long> idsQuery = queryFactory
-                    .select(archiveStats.id)
-                    .from(archiveStats)
-                    .where(
-                            eqUserIdForStats(filterUserId),
-                            inVisibilitiesForStats(allowedVisibilities)
-                    )
-                    .orderBy(getStatsOrderSpecifiers(pageable))
-                    .offset(pageable.getOffset())
-                    .limit(pageable.getPageSize());
+            ids = paginationIdCacheService.getIds(idsCacheKey, () -> {
+                JPAQuery<Long> idsQuery = queryFactory
+                        .select(archiveStats.id)
+                        .from(archiveStats)
+                        .where(
+                                eqUserIdForStats(filterUserId),
+                                inVisibilitiesForStats(allowedVisibilities)
+                        )
+                        .orderBy(getStatsOrderSpecifiers(pageable))
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize());
 
-            // 필터 유저가 있으면 조인 필요
-            if (filterUserId != null) {
-                idsQuery.join(archiveStats.archive, archive);
-            }
+                if (filterUserId != null) {
+                    idsQuery.join(archiveStats.archive, archive);
+                }
 
-            ids = idsQuery.fetch();
+                return idsQuery.fetch();
+            });
 
             // Count Query (ArchiveStats 테이블 대상)
             countQuery = queryFactory
@@ -141,6 +156,7 @@ public class ArchiveQueryRepository {
 
             sortedContent = ids.stream()
                     .map(contentMap::get)
+                    .filter(Objects::nonNull)
                     .collect(Collectors.toList());
         }
 

--- a/src/main/java/com/depth/deokive/domain/archive/repository/ArchiveQueryRepository.java
+++ b/src/main/java/com/depth/deokive/domain/archive/repository/ArchiveQueryRepository.java
@@ -1,5 +1,6 @@
 package com.depth.deokive.domain.archive.repository;
 
+import com.depth.deokive.common.service.PaginationCountCacheService;
 import com.depth.deokive.domain.archive.dto.ArchiveDto;
 import com.depth.deokive.domain.archive.dto.QArchiveDto_ArchivePageResponse;
 import com.depth.deokive.common.enums.Visibility;
@@ -29,6 +30,7 @@ import static com.depth.deokive.domain.archive.entity.QArchiveStats.archiveStats
 public class ArchiveQueryRepository {
 
     private final JPAQueryFactory queryFactory;
+    private final PaginationCountCacheService paginationCountCacheService;
 
     public Page<ArchiveDto.ArchivePageResponse> searchArchiveFeed(
             Long filterUserId,
@@ -42,9 +44,18 @@ public class ArchiveQueryRepository {
         List<Long> ids;
         JPAQuery<Long> countQuery;
 
+        // Count 캐시 키 구성 (visibility 조합 포함)
+        String visKey = allowedVisibilities.stream()
+                .map(Visibility::name)
+                .sorted()
+                .collect(Collectors.joining(","));
+        String countCacheKey;
+
         // STEP 2. 커버링 인덱스 활용 (ID만 조회) && 정렬 조건 분기 : My Archives vs Global Archives
         if (isOptimizedPath) {
             // Case 1. My Archives(Me or Friends) -> Archive Table Scan
+            countCacheKey = "archive:opt:" + filterUserId + ":" + visKey;
+
             ids = queryFactory
                     .select(archive.id)
                     .from(archive)
@@ -66,6 +77,8 @@ public class ArchiveQueryRepository {
                     );
         } else {
             // Case 2. Global Archives -> ArchiveStats 기반 조회
+            countCacheKey = "archive:global:" + (filterUserId != null ? filterUserId : "all") + ":" + visKey;
+
             JPAQuery<Long> idsQuery = queryFactory
                     .select(archiveStats.id)
                     .from(archiveStats)
@@ -131,7 +144,10 @@ public class ArchiveQueryRepository {
                     .collect(Collectors.toList());
         }
 
-        return PageableExecutionUtils.getPage(sortedContent, pageable, countQuery::fetchOne);
+        // Count Query - Redis 캐싱으로 동시 요청 시 DB 부하 제거
+        final JPAQuery<Long> finalCountQuery = countQuery;
+        return PageableExecutionUtils.getPage(sortedContent, pageable,
+                () -> paginationCountCacheService.getCount(countCacheKey, finalCountQuery::fetchOne));
     }
 
     // --- Dynamic Filters ---

--- a/src/main/java/com/depth/deokive/domain/archive/service/ArchiveService.java
+++ b/src/main/java/com/depth/deokive/domain/archive/service/ArchiveService.java
@@ -5,6 +5,7 @@ import com.depth.deokive.common.enums.ViewLikeDomain;
 import com.depth.deokive.common.service.ArchiveGuard;
 import com.depth.deokive.common.service.LikeRedisService;
 import com.depth.deokive.common.service.PaginationCountCacheService;
+import com.depth.deokive.common.service.PaginationIdCacheService;
 import com.depth.deokive.common.service.RedisViewService;
 import com.depth.deokive.common.util.ClientUtils;
 import com.depth.deokive.common.util.FileUrlUtils;
@@ -62,6 +63,7 @@ public class ArchiveService {
     private final ArchiveQueryRepository archiveQueryRepository;
     private final LikeRedisService likeRedisService;
     private final PaginationCountCacheService paginationCountCacheService;
+    private final PaginationIdCacheService paginationIdCacheService;
 
     // --- Sub-Domain Content Repositories (For Bulk Delete) ---
     private final EventRepository eventRepository;
@@ -108,8 +110,9 @@ public class ArchiveService {
         ArchiveStats stats = ArchiveStats.create(archive);
         archiveStatsRepository.save(stats);
 
-        // SEQ 7. 페이지네이션 COUNT 캐시 무효화
+        // SEQ 7. 페이지네이션 캐시 무효화
         paginationCountCacheService.evictByPrefix("archive");
+        paginationIdCacheService.evictByPrefix("archive");
 
         // SEQ 8. Response
         String bannerUrl = (archive.getBannerFile() != null)
@@ -191,9 +194,10 @@ public class ArchiveService {
         // SEQ 4. 배너 수정
         String bannerUrl = updateBannerImage(archive, request.getBannerImageId(), user.getUserId());
 
-        // SEQ 5. 공개 범위(Visibility) 변경 시 Stats 테이블 동기화
+        // SEQ 5. 공개 범위(Visibility) 변경 시 Stats 테이블 동기화 + 캐시 무효화
         if (request.getVisibility() != null) {
             archiveStatsRepository.syncVisibility(archive.getId(), request.getVisibility());
+            paginationIdCacheService.evictByPrefix("archive");
         }
 
         // SEQ 6. 리턴용 조회
@@ -268,6 +272,7 @@ public class ArchiveService {
         // Step 4. Redis 캐시 삭제 (좋아요 + 페이지네이션 COUNT)
         likeRedisService.deleteLikeData(ViewLikeDomain.ARCHIVE, archiveId);
         paginationCountCacheService.evictByPrefix("archive");
+        paginationIdCacheService.evictByPrefix("archive");
 
         log.info("🟢 Archive Delete Completed.");
     }

--- a/src/main/java/com/depth/deokive/domain/archive/service/ArchiveService.java
+++ b/src/main/java/com/depth/deokive/domain/archive/service/ArchiveService.java
@@ -4,6 +4,7 @@ import com.depth.deokive.common.dto.PageDto;
 import com.depth.deokive.common.enums.ViewLikeDomain;
 import com.depth.deokive.common.service.ArchiveGuard;
 import com.depth.deokive.common.service.LikeRedisService;
+import com.depth.deokive.common.service.PaginationCountCacheService;
 import com.depth.deokive.common.service.RedisViewService;
 import com.depth.deokive.common.util.ClientUtils;
 import com.depth.deokive.common.util.FileUrlUtils;
@@ -60,6 +61,7 @@ public class ArchiveService {
     private final ArchiveStatsRepository archiveStatsRepository;
     private final ArchiveQueryRepository archiveQueryRepository;
     private final LikeRedisService likeRedisService;
+    private final PaginationCountCacheService paginationCountCacheService;
 
     // --- Sub-Domain Content Repositories (For Bulk Delete) ---
     private final EventRepository eventRepository;
@@ -106,7 +108,10 @@ public class ArchiveService {
         ArchiveStats stats = ArchiveStats.create(archive);
         archiveStatsRepository.save(stats);
 
-        // SEQ 7. Response
+        // SEQ 7. 페이지네이션 COUNT 캐시 무효화
+        paginationCountCacheService.evictByPrefix("archive");
+
+        // SEQ 8. Response
         String bannerUrl = (archive.getBannerFile() != null)
                 ? FileUrlUtils.buildCdnUrl(archive.getBannerFile().getS3ObjectKey())
                 : null;
@@ -260,8 +265,9 @@ public class ArchiveService {
         // Cascade -> Sub Domain 삭제: DiaryBook, GalleryBook, TicketBook, RepostBook, Banner
         archiveRepository.delete(archive);
 
-        // Step 4. Redis 캐시 삭제
+        // Step 4. Redis 캐시 삭제 (좋아요 + 페이지네이션 COUNT)
         likeRedisService.deleteLikeData(ViewLikeDomain.ARCHIVE, archiveId);
+        paginationCountCacheService.evictByPrefix("archive");
 
         log.info("🟢 Archive Delete Completed.");
     }

--- a/src/main/java/com/depth/deokive/domain/archive/service/ArchiveService.java
+++ b/src/main/java/com/depth/deokive/domain/archive/service/ArchiveService.java
@@ -337,7 +337,6 @@ public class ArchiveService {
     /**
      * 아카이브 좋아요 토글 (Redis + RabbitMQ)
      */
-    @Transactional
     public ArchiveDto.LikeResponse toggleLike(UserPrincipal userPrincipal, Long archiveId) {
         // 1. 아카이브 존재 확인 (불필요한 Redis 연산 방지)
         // if (!archiveRepository.existsById(archiveId)) {

--- a/src/main/java/com/depth/deokive/domain/diary/repository/DiaryQueryRepository.java
+++ b/src/main/java/com/depth/deokive/domain/diary/repository/DiaryQueryRepository.java
@@ -2,6 +2,7 @@ package com.depth.deokive.domain.diary.repository;
 
 import com.depth.deokive.common.enums.Visibility;
 import com.depth.deokive.common.service.PaginationCountCacheService;
+import com.depth.deokive.common.service.PaginationIdCacheService;
 import com.depth.deokive.domain.diary.dto.DiaryDto;
 import com.depth.deokive.domain.diary.dto.QDiaryDto_DiaryPageResponse;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -23,24 +24,34 @@ public class DiaryQueryRepository {
 
     private final JPAQueryFactory queryFactory;
     private final PaginationCountCacheService paginationCountCacheService;
+    private final PaginationIdCacheService paginationIdCacheService;
 
     public Page<DiaryDto.DiaryPageResponse> findDiaries(
             Long bookId,
             List<Visibility> allowedVisibilities,
             Pageable pageable
     ) {
-        // SEQ 1. Covering Index
-        List<Long> ids = queryFactory
-                .select(diary.id)
-                .from(diary)
-                .where(
-                        diary.diaryBook.id.eq(bookId),
-                        eqVisibility(allowedVisibilities) // 친구 사이여도 Private는 안옴
-                )
-                .orderBy(diary.recordedAt.desc(), diary.id.desc()) // Tie-Breaker 추가
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+        // SEQ 1. Covering Index - Redis 캐싱
+        String visKey = allowedVisibilities.stream()
+                .map(Visibility::name)
+                .sorted()
+                .collect(java.util.stream.Collectors.joining(","));
+        String idsCacheKey = "diary:" + bookId + ":" + visKey
+                + ":" + pageable.getPageNumber() + ":" + pageable.getPageSize();
+
+        List<Long> ids = paginationIdCacheService.getIds(idsCacheKey, () ->
+                queryFactory
+                        .select(diary.id)
+                        .from(diary)
+                        .where(
+                                diary.diaryBook.id.eq(bookId),
+                                eqVisibility(allowedVisibilities)
+                        )
+                        .orderBy(diary.recordedAt.desc(), diary.id.desc())
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch()
+        );
 
         List<DiaryDto.DiaryPageResponse> content = new ArrayList<>();
 
@@ -61,10 +72,6 @@ public class DiaryQueryRepository {
         }
 
         // SEQ 3. Count Query - Redis 캐싱
-        String visKey = allowedVisibilities.stream()
-                .map(Visibility::name)
-                .sorted()
-                .collect(java.util.stream.Collectors.joining(","));
         String countCacheKey = "diary:" + bookId + ":" + visKey;
 
         return PageableExecutionUtils.getPage(content, pageable,

--- a/src/main/java/com/depth/deokive/domain/diary/repository/DiaryQueryRepository.java
+++ b/src/main/java/com/depth/deokive/domain/diary/repository/DiaryQueryRepository.java
@@ -1,10 +1,10 @@
 package com.depth.deokive.domain.diary.repository;
 
 import com.depth.deokive.common.enums.Visibility;
+import com.depth.deokive.common.service.PaginationCountCacheService;
 import com.depth.deokive.domain.diary.dto.DiaryDto;
 import com.depth.deokive.domain.diary.dto.QDiaryDto_DiaryPageResponse;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -22,6 +22,7 @@ import static com.depth.deokive.domain.diary.entity.QDiary.diary;
 public class DiaryQueryRepository {
 
     private final JPAQueryFactory queryFactory;
+    private final PaginationCountCacheService paginationCountCacheService;
 
     public Page<DiaryDto.DiaryPageResponse> findDiaries(
             Long bookId,
@@ -59,16 +60,23 @@ public class DiaryQueryRepository {
                     .fetch();
         }
 
-        // SEQ 3. Count Query
-        JPAQuery<Long> countQuery = queryFactory
-                .select(diary.count())
-                .from(diary)
-                .where(
-                        diary.diaryBook.id.eq(bookId),
-                        eqVisibility(allowedVisibilities)
-                );
+        // SEQ 3. Count Query - Redis 캐싱
+        String visKey = allowedVisibilities.stream()
+                .map(Visibility::name)
+                .sorted()
+                .collect(java.util.stream.Collectors.joining(","));
+        String countCacheKey = "diary:" + bookId + ":" + visKey;
 
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+        return PageableExecutionUtils.getPage(content, pageable,
+                () -> paginationCountCacheService.getCount(countCacheKey, () ->
+                        queryFactory.select(diary.count())
+                                .from(diary)
+                                .where(
+                                        diary.diaryBook.id.eq(bookId),
+                                        eqVisibility(allowedVisibilities)
+                                )
+                                .fetchOne()
+                ));
     }
 
     private BooleanExpression eqVisibility(List<Visibility> allowedVisibilities) {

--- a/src/main/java/com/depth/deokive/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/depth/deokive/domain/diary/service/DiaryService.java
@@ -3,6 +3,7 @@ package com.depth.deokive.domain.diary.service;
 import com.depth.deokive.common.dto.PageDto;
 import com.depth.deokive.common.service.ArchiveGuard;
 import com.depth.deokive.common.service.PaginationCountCacheService;
+import com.depth.deokive.common.service.PaginationIdCacheService;
 import com.depth.deokive.common.util.PageUtils;
 import com.depth.deokive.common.util.ThumbnailUtils;
 import com.depth.deokive.common.enums.Visibility;
@@ -40,6 +41,7 @@ public class DiaryService {
     private final FileService fileService;
     private final DiaryQueryRepository diaryQueryRepository;
     private final PaginationCountCacheService paginationCountCacheService;
+    private final PaginationIdCacheService paginationIdCacheService;
 
     @Transactional
     public DiaryDto.Response createDiary(UserPrincipal userPrincipal, Long archiveId, DiaryDto.CreateRequest request) {
@@ -60,8 +62,9 @@ public class DiaryService {
         // SEQ 5. 썸네일 업데이트
         updateDiaryThumbnail(diary, maps);
 
-        // SEQ 6. 페이지네이션 COUNT 캐시 무효화
+        // SEQ 6. 페이지네이션 캐시 무효화
         paginationCountCacheService.evictByPrefix("diary:" + archiveId);
+        paginationIdCacheService.evictByPrefix("diary:" + archiveId);
 
         return DiaryDto.Response.of(diary, maps);
     }
@@ -123,8 +126,9 @@ public class DiaryService {
         diaryFileMapRepository.deleteAllByDiaryId(diaryId);
         diaryRepository.delete(diary);
 
-        // SEQ 4. 페이지네이션 COUNT 캐시 무효화
+        // SEQ 4. 페이지네이션 캐시 무효화
         paginationCountCacheService.evictByPrefix("diary:" + diary.getDiaryBook().getId());
+        paginationIdCacheService.evictByPrefix("diary:" + diary.getDiaryBook().getId());
     }
 
     @Transactional

--- a/src/main/java/com/depth/deokive/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/depth/deokive/domain/diary/service/DiaryService.java
@@ -2,6 +2,7 @@ package com.depth.deokive.domain.diary.service;
 
 import com.depth.deokive.common.dto.PageDto;
 import com.depth.deokive.common.service.ArchiveGuard;
+import com.depth.deokive.common.service.PaginationCountCacheService;
 import com.depth.deokive.common.util.PageUtils;
 import com.depth.deokive.common.util.ThumbnailUtils;
 import com.depth.deokive.common.enums.Visibility;
@@ -38,6 +39,7 @@ public class DiaryService {
     private final DiaryFileMapRepository diaryFileMapRepository;
     private final FileService fileService;
     private final DiaryQueryRepository diaryQueryRepository;
+    private final PaginationCountCacheService paginationCountCacheService;
 
     @Transactional
     public DiaryDto.Response createDiary(UserPrincipal userPrincipal, Long archiveId, DiaryDto.CreateRequest request) {
@@ -57,6 +59,9 @@ public class DiaryService {
 
         // SEQ 5. 썸네일 업데이트
         updateDiaryThumbnail(diary, maps);
+
+        // SEQ 6. 페이지네이션 COUNT 캐시 무효화
+        paginationCountCacheService.evictByPrefix("diary:" + archiveId);
 
         return DiaryDto.Response.of(diary, maps);
     }
@@ -117,6 +122,9 @@ public class DiaryService {
         // SEQ 3. Diary와 관련된 모든 매핑 제거 -> 다이어리 제거 (Cascade가 아닌 명시적 제거)
         diaryFileMapRepository.deleteAllByDiaryId(diaryId);
         diaryRepository.delete(diary);
+
+        // SEQ 4. 페이지네이션 COUNT 캐시 무효화
+        paginationCountCacheService.evictByPrefix("diary:" + diary.getDiaryBook().getId());
     }
 
     @Transactional

--- a/src/main/java/com/depth/deokive/domain/gallery/repository/GalleryQueryRepository.java
+++ b/src/main/java/com/depth/deokive/domain/gallery/repository/GalleryQueryRepository.java
@@ -1,6 +1,7 @@
 package com.depth.deokive.domain.gallery.repository;
 
 import com.depth.deokive.common.service.PaginationCountCacheService;
+import com.depth.deokive.common.service.PaginationIdCacheService;
 import com.depth.deokive.domain.gallery.dto.GalleryDto;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.depth.deokive.domain.archive.entity.QArchive.archive;
 import static com.depth.deokive.domain.file.entity.QFile.file;
@@ -26,19 +28,28 @@ public class GalleryQueryRepository {
 
     private final JPAQueryFactory queryFactory;
     private final PaginationCountCacheService paginationCountCacheService;
+    private final PaginationIdCacheService paginationIdCacheService;
 
     public Page<GalleryDto.Response> searchGalleriesByArchive(Long archiveId, Pageable pageable) {
 
-        // STEP 1. 커버링 인덱스 활용 (ID만 조회)
-        // created_at 정렬 인덱스를 타므로 매우 빠름. 데이터 블록 접근 X
-        List<Long> ids = queryFactory
-                .select(gallery.id)
-                .from(gallery)
-                .where(gallery.archiveId.eq(archiveId)) // 반정규화된 컬럼 사용
-                .orderBy(getOrderSpecifiers(pageable))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+        // STEP 1. 커버링 인덱스 활용 (ID만 조회) - Redis 캐싱
+        String sortKey = pageable.getSort().stream()
+                .map(o -> o.getProperty() + "_" + o.getDirection())
+                .collect(Collectors.joining(","));
+        String idsCacheKey = "gallery:" + archiveId
+                + ":" + (sortKey.isEmpty() ? "default" : sortKey)
+                + ":" + pageable.getPageNumber() + ":" + pageable.getPageSize();
+
+        List<Long> ids = paginationIdCacheService.getIds(idsCacheKey, () ->
+                queryFactory
+                        .select(gallery.id)
+                        .from(gallery)
+                        .where(gallery.archiveId.eq(archiveId))
+                        .orderBy(getOrderSpecifiers(pageable))
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch()
+        );
 
         // STEP 2. 데이터 조회 (WHERE IN)
         // 찾아낸 소수의 ID에 대해서만 File 조인 수행

--- a/src/main/java/com/depth/deokive/domain/gallery/repository/GalleryQueryRepository.java
+++ b/src/main/java/com/depth/deokive/domain/gallery/repository/GalleryQueryRepository.java
@@ -1,10 +1,10 @@
 package com.depth.deokive.domain.gallery.repository;
 
+import com.depth.deokive.common.service.PaginationCountCacheService;
 import com.depth.deokive.domain.gallery.dto.GalleryDto;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -25,6 +25,7 @@ import static com.depth.deokive.domain.gallery.entity.QGallery.gallery;
 public class GalleryQueryRepository {
 
     private final JPAQueryFactory queryFactory;
+    private final PaginationCountCacheService paginationCountCacheService;
 
     public Page<GalleryDto.Response> searchGalleriesByArchive(Long archiveId, Pageable pageable) {
 
@@ -57,13 +58,16 @@ public class GalleryQueryRepository {
                     .fetch();
         }
 
-        // Count Query (최적화)
-        JPAQuery<Long> countQuery = queryFactory
-                .select(gallery.count())
-                .from(gallery)
-                .where(gallery.archiveId.eq(archiveId));
+        // Count Query - Redis 캐싱
+        String countCacheKey = "gallery:" + archiveId;
 
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+        return PageableExecutionUtils.getPage(content, pageable,
+                () -> paginationCountCacheService.getCount(countCacheKey, () ->
+                        queryFactory.select(gallery.count())
+                                .from(gallery)
+                                .where(gallery.archiveId.eq(archiveId))
+                                .fetchOne()
+                ));
     }
 
     private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {

--- a/src/main/java/com/depth/deokive/domain/gallery/service/GalleryService.java
+++ b/src/main/java/com/depth/deokive/domain/gallery/service/GalleryService.java
@@ -2,6 +2,7 @@ package com.depth.deokive.domain.gallery.service;
 
 import com.depth.deokive.common.dto.PageDto;
 import com.depth.deokive.common.service.ArchiveGuard;
+import com.depth.deokive.common.service.PaginationCountCacheService;
 import com.depth.deokive.common.util.PageUtils;
 import com.depth.deokive.domain.archive.entity.Archive;
 import com.depth.deokive.domain.archive.repository.ArchiveRepository;
@@ -36,6 +37,7 @@ public class GalleryService {
     private final ArchiveRepository archiveRepository;
     private final GalleryRepository galleryRepository;
     private final FileService fileService;
+    private final PaginationCountCacheService paginationCountCacheService;
 
     @ExecutionTime
     @Transactional(readOnly = true)
@@ -81,6 +83,8 @@ public class GalleryService {
 
         galleryRepository.saveAll(galleries);
 
+        paginationCountCacheService.evict("gallery:" + archiveId);
+
         return GalleryDto.CreateResponse.builder()
                 .createdCount(galleries.size())
                 .archiveId(archiveId)
@@ -113,5 +117,7 @@ public class GalleryService {
 
         archiveGuard.checkOwner(archive.getUser().getId(), userPrincipal);
         galleryRepository.deleteByIdsAndArchiveId(request.getGalleryIds(), archiveId);
+
+        paginationCountCacheService.evict("gallery:" + archiveId);
     }
 }

--- a/src/main/java/com/depth/deokive/domain/gallery/service/GalleryService.java
+++ b/src/main/java/com/depth/deokive/domain/gallery/service/GalleryService.java
@@ -3,6 +3,7 @@ package com.depth.deokive.domain.gallery.service;
 import com.depth.deokive.common.dto.PageDto;
 import com.depth.deokive.common.service.ArchiveGuard;
 import com.depth.deokive.common.service.PaginationCountCacheService;
+import com.depth.deokive.common.service.PaginationIdCacheService;
 import com.depth.deokive.common.util.PageUtils;
 import com.depth.deokive.domain.archive.entity.Archive;
 import com.depth.deokive.domain.archive.repository.ArchiveRepository;
@@ -38,6 +39,7 @@ public class GalleryService {
     private final GalleryRepository galleryRepository;
     private final FileService fileService;
     private final PaginationCountCacheService paginationCountCacheService;
+    private final PaginationIdCacheService paginationIdCacheService;
 
     @ExecutionTime
     @Transactional(readOnly = true)
@@ -84,6 +86,7 @@ public class GalleryService {
         galleryRepository.saveAll(galleries);
 
         paginationCountCacheService.evict("gallery:" + archiveId);
+        paginationIdCacheService.evictByPrefix("gallery:" + archiveId);
 
         return GalleryDto.CreateResponse.builder()
                 .createdCount(galleries.size())
@@ -119,5 +122,6 @@ public class GalleryService {
         galleryRepository.deleteByIdsAndArchiveId(request.getGalleryIds(), archiveId);
 
         paginationCountCacheService.evict("gallery:" + archiveId);
+        paginationIdCacheService.evictByPrefix("gallery:" + archiveId);
     }
 }

--- a/src/main/java/com/depth/deokive/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/com/depth/deokive/domain/post/repository/PostQueryRepository.java
@@ -1,5 +1,6 @@
 package com.depth.deokive.domain.post.repository;
 
+import com.depth.deokive.common.service.PaginationCountCacheService;
 import com.depth.deokive.domain.post.dto.PostDto;
 
 
@@ -8,7 +9,6 @@ import com.depth.deokive.domain.post.entity.enums.Category;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -31,6 +31,7 @@ import static com.depth.deokive.domain.post.entity.QPostStats.postStats;
 public class PostQueryRepository {
 
     private final JPAQueryFactory queryFactory;
+    private final PaginationCountCacheService paginationCountCacheService;
 
     public Page<PostDto.PostPageResponse> searchPostFeed(Category category, Pageable pageable) {
 
@@ -74,13 +75,16 @@ public class PostQueryRepository {
             sortedContent = ids.stream().map(contentMap::get).toList();
         }
 
-        // Count Query (PostStats 기준)
-        JPAQuery<Long> countQuery = queryFactory
-                .select(postStats.count())
-                .from(postStats)
-                .where(eqCategory(category));
+        // Count Query (PostStats 기준) - Caffeine L1 캐싱으로 동시 요청 시 DB 부하 제거
+        String countCacheKey = "post:feed:" + (category != null ? category.name() : "ALL");
 
-        return PageableExecutionUtils.getPage(sortedContent, pageable, countQuery::fetchOne);
+        return PageableExecutionUtils.getPage(sortedContent, pageable,
+                () -> paginationCountCacheService.getCount(countCacheKey, () ->
+                        queryFactory.select(postStats.count())
+                                .from(postStats)
+                                .where(eqCategory(category))
+                                .fetchOne()
+                ));
     }
 
     private BooleanExpression eqCategory(Category category) {

--- a/src/main/java/com/depth/deokive/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/com/depth/deokive/domain/post/repository/PostQueryRepository.java
@@ -1,6 +1,7 @@
 package com.depth.deokive.domain.post.repository;
 
 import com.depth.deokive.common.service.PaginationCountCacheService;
+import com.depth.deokive.common.service.PaginationIdCacheService;
 import com.depth.deokive.domain.post.dto.PostDto;
 
 
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Repository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -32,18 +34,28 @@ public class PostQueryRepository {
 
     private final JPAQueryFactory queryFactory;
     private final PaginationCountCacheService paginationCountCacheService;
+    private final PaginationIdCacheService paginationIdCacheService;
 
     public Page<PostDto.PostPageResponse> searchPostFeed(Category category, Pageable pageable) {
 
-        // STEP 1. 커버링 인덱스 활용 (ID 조회)
-        List<Long> ids = queryFactory
-                .select(postStats.id)
-                .from(postStats)
-                .where(eqCategory(category)) // postStats.category 사용
-                .orderBy(getOrderSpecifiers(pageable)) // postStats 기준 정렬
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+        // STEP 1. 커버링 인덱스 활용 (ID 조회) - Redis 캐싱
+        String sortKey = pageable.getSort().stream()
+                .map(o -> o.getProperty() + "_" + o.getDirection())
+                .collect(Collectors.joining(","));
+        String idsCacheKey = "post:feed:" + (category != null ? category.name() : "ALL")
+                + ":" + (sortKey.isEmpty() ? "default" : sortKey)
+                + ":" + pageable.getPageNumber() + ":" + pageable.getPageSize();
+
+        List<Long> ids = paginationIdCacheService.getIds(idsCacheKey, () ->
+                queryFactory
+                        .select(postStats.id)
+                        .from(postStats)
+                        .where(eqCategory(category))
+                        .orderBy(getOrderSpecifiers(pageable))
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch()
+        );
 
         // STEP 2. 데이터 조회 (Post + PostStats + User Fetch Join)
         List<PostDto.PostPageResponse> sortedContent = new ArrayList<>();
@@ -72,7 +84,7 @@ public class PostQueryRepository {
             Map<Long, PostDto.PostPageResponse> contentMap = content.stream()
                     .collect(Collectors.toMap(PostDto.PostPageResponse::getPostId, Function.identity()));
 
-            sortedContent = ids.stream().map(contentMap::get).toList();
+            sortedContent = ids.stream().map(contentMap::get).filter(Objects::nonNull).toList();
         }
 
         // Count Query (PostStats 기준) - Caffeine L1 캐싱으로 동시 요청 시 DB 부하 제거

--- a/src/main/java/com/depth/deokive/domain/post/repository/RepostQueryRepository.java
+++ b/src/main/java/com/depth/deokive/domain/post/repository/RepostQueryRepository.java
@@ -1,11 +1,11 @@
 package com.depth.deokive.domain.post.repository;
 
 
+import com.depth.deokive.common.service.PaginationCountCacheService;
 import com.depth.deokive.domain.post.dto.RepostDto;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -24,6 +24,7 @@ import static com.depth.deokive.domain.post.entity.QRepost.repost;
 public class RepostQueryRepository {
 
     private final JPAQueryFactory queryFactory;
+    private final PaginationCountCacheService paginationCountCacheService;
 
     public Page<RepostDto.RepostElementResponse> findByTabId(Long tabId, Pageable pageable) {
 
@@ -57,12 +58,15 @@ public class RepostQueryRepository {
                     .fetch();
         }
 
-        // SEQ 4. Count Query
-        JPAQuery<Long> countQuery = queryFactory
-                .select(repost.count())
-                .from(repost)
-                .where(repost.repostTab.id.eq(tabId));
+        // SEQ 4. Count Query - Redis 캐싱 (탭별 캐시)
+        String countCacheKey = "repost:" + tabId;
 
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+        return PageableExecutionUtils.getPage(content, pageable,
+                () -> paginationCountCacheService.getCount(countCacheKey, () ->
+                        queryFactory.select(repost.count())
+                                .from(repost)
+                                .where(repost.repostTab.id.eq(tabId))
+                                .fetchOne()
+                ));
     }
 }

--- a/src/main/java/com/depth/deokive/domain/post/repository/RepostQueryRepository.java
+++ b/src/main/java/com/depth/deokive/domain/post/repository/RepostQueryRepository.java
@@ -2,6 +2,7 @@ package com.depth.deokive.domain.post.repository;
 
 
 import com.depth.deokive.common.service.PaginationCountCacheService;
+import com.depth.deokive.common.service.PaginationIdCacheService;
 import com.depth.deokive.domain.post.dto.RepostDto;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -25,18 +26,24 @@ public class RepostQueryRepository {
 
     private final JPAQueryFactory queryFactory;
     private final PaginationCountCacheService paginationCountCacheService;
+    private final PaginationIdCacheService paginationIdCacheService;
 
     public Page<RepostDto.RepostElementResponse> findByTabId(Long tabId, Pageable pageable) {
 
-        // SEQ 1. ID로 조회
-        List<Long> ids = queryFactory
-                .select(repost.id)
-                .from(repost)
-                .where(repost.repostTab.id.eq(tabId))
-                .orderBy(repost.createdAt.desc(), repost.id.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+        // SEQ 1. ID로 조회 - Redis 캐싱 (정렬 고정)
+        String idsCacheKey = "repost:" + tabId
+                + ":" + pageable.getPageNumber() + ":" + pageable.getPageSize();
+
+        List<Long> ids = paginationIdCacheService.getIds(idsCacheKey, () ->
+                queryFactory
+                        .select(repost.id)
+                        .from(repost)
+                        .where(repost.repostTab.id.eq(tabId))
+                        .orderBy(repost.createdAt.desc(), repost.id.desc())
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch()
+        );
 
         List<RepostDto.RepostElementResponse> content = new ArrayList<>();
 

--- a/src/main/java/com/depth/deokive/domain/post/service/PostService.java
+++ b/src/main/java/com/depth/deokive/domain/post/service/PostService.java
@@ -4,6 +4,7 @@ import com.depth.deokive.common.dto.PageDto;
 import com.depth.deokive.common.enums.ViewLikeDomain;
 import com.depth.deokive.common.service.LikeRedisService;
 import com.depth.deokive.common.service.PaginationCountCacheService;
+import com.depth.deokive.common.service.PaginationIdCacheService;
 import com.depth.deokive.common.service.RedisViewService;
 import com.depth.deokive.common.util.ClientUtils;
 import com.depth.deokive.common.util.PageUtils;
@@ -52,6 +53,7 @@ public class PostService {
     private final CommentCountRedisService commentCountRedisService;
     private final CommentRepository commentRepository;
     private final PaginationCountCacheService paginationCountCacheService;
+    private final PaginationIdCacheService paginationIdCacheService;
 
     @Transactional
     public PostDto.Response createPost(UserPrincipal userPrincipal, PostDto.CreateRequest request) {
@@ -70,8 +72,9 @@ public class PostService {
         // SEQ 4. 파일 연결
         List<PostFileMap> maps = connectFilesToPost(post, request.getFiles(), userPrincipal.getUserId());
 
-        // SEQ 5. 페이지네이션 COUNT 캐시 무효화
+        // SEQ 5. 페이지네이션 캐시 무효화
         paginationCountCacheService.evictByPrefix("post");
+        paginationIdCacheService.evictByPrefix("post");
 
         // SEQ 6. Response (생성 시점에는 좋아요 없음)
         return PostDto.Response.of(post, stats, maps, false);
@@ -134,6 +137,7 @@ public class PostService {
         // SEQ 4. 카테고리가 변경되었다면 PostStats도 동기화 (커버링 인덱스용)
         if (request.getCategory() != null) {
             postStatsRepository.syncUpdateCategory(postId, request.getCategory());
+            paginationIdCacheService.evictByPrefix("post");
         }
 
         // SEQ 5. 기존 파일 매핑 삭제 후 재생성 (🧐 파일의 순서, 파일 자체, 미디어 역할 등이 변경될 수 있음 -> 일괄 삭제 후 재매핑이 나음)
@@ -184,10 +188,11 @@ public class PostService {
         // SEQ 7. 게시글 삭제
         postRepository.delete(post);
 
-        // SEQ 8. 캐시 삭제 (좋아요 + 댓글 수 + 페이지네이션 COUNT)
+        // SEQ 8. 캐시 삭제 (좋아요 + 댓글 수 + 페이지네이션)
         likeRedisService.deleteLikeData(ViewLikeDomain.POST, postId);
         commentCountRedisService.deleteCache(postId);
         paginationCountCacheService.evictByPrefix("post");
+        paginationIdCacheService.evictByPrefix("post");
     }
 
     @ExecutionTime

--- a/src/main/java/com/depth/deokive/domain/post/service/PostService.java
+++ b/src/main/java/com/depth/deokive/domain/post/service/PostService.java
@@ -3,6 +3,7 @@ package com.depth.deokive.domain.post.service;
 import com.depth.deokive.common.dto.PageDto;
 import com.depth.deokive.common.enums.ViewLikeDomain;
 import com.depth.deokive.common.service.LikeRedisService;
+import com.depth.deokive.common.service.PaginationCountCacheService;
 import com.depth.deokive.common.service.RedisViewService;
 import com.depth.deokive.common.util.ClientUtils;
 import com.depth.deokive.common.util.PageUtils;
@@ -50,6 +51,7 @@ public class PostService {
     private final LikeRedisService likeRedisService;
     private final CommentCountRedisService commentCountRedisService;
     private final CommentRepository commentRepository;
+    private final PaginationCountCacheService paginationCountCacheService;
 
     @Transactional
     public PostDto.Response createPost(UserPrincipal userPrincipal, PostDto.CreateRequest request) {
@@ -68,7 +70,10 @@ public class PostService {
         // SEQ 4. 파일 연결
         List<PostFileMap> maps = connectFilesToPost(post, request.getFiles(), userPrincipal.getUserId());
 
-        // SEQ 5. Response (생성 시점에는 좋아요 없음)
+        // SEQ 5. 페이지네이션 COUNT 캐시 무효화
+        paginationCountCacheService.evictByPrefix("post");
+
+        // SEQ 6. Response (생성 시점에는 좋아요 없음)
         return PostDto.Response.of(post, stats, maps, false);
     }
 
@@ -179,9 +184,10 @@ public class PostService {
         // SEQ 7. 게시글 삭제
         postRepository.delete(post);
 
-        // SEQ 8. 캐시 삭제 (좋아요 + 댓글 수)
+        // SEQ 8. 캐시 삭제 (좋아요 + 댓글 수 + 페이지네이션 COUNT)
         likeRedisService.deleteLikeData(ViewLikeDomain.POST, postId);
         commentCountRedisService.deleteCache(postId);
+        paginationCountCacheService.evictByPrefix("post");
     }
 
     @ExecutionTime

--- a/src/main/java/com/depth/deokive/domain/post/service/PostService.java
+++ b/src/main/java/com/depth/deokive/domain/post/service/PostService.java
@@ -213,7 +213,6 @@ public class PostService {
         return PageDto.PageListResponse.of(title, page);
     }
 
-    @Transactional
     public PostDto.LikeResponse toggleLike(UserPrincipal userPrincipal, Long postId) {
         boolean isLiked = likeRedisService.toggleLike(
                 ViewLikeDomain.POST,

--- a/src/main/java/com/depth/deokive/domain/post/service/RepostService.java
+++ b/src/main/java/com/depth/deokive/domain/post/service/RepostService.java
@@ -1,6 +1,7 @@
 package com.depth.deokive.domain.post.service;
 
 import com.depth.deokive.common.service.ArchiveGuard;
+import com.depth.deokive.common.service.PaginationCountCacheService;
 import com.depth.deokive.common.util.PageUtils;
 import com.depth.deokive.common.util.TextUtils;
 import com.depth.deokive.domain.archive.entity.Archive;
@@ -44,6 +45,7 @@ public class RepostService {
     private final ArchiveRepository archiveRepository;
 
     private final RepostOgProducer repostOgProducer;
+    private final PaginationCountCacheService paginationCountCacheService;
 
     /**
      * Repost 생성 - 비동기 OG 추출 (RabbitMQ)
@@ -95,7 +97,10 @@ public class RepostService {
         // SEQ 5. RabbitMQ 발행 (트랜잭션 커밋 후 실제 전송, SSE 알림용 userId 포함)
         repostOgProducer.requestOgExtraction(repost.getId(), userPrincipal.getUserId(), url);
 
-        // SEQ 6. 즉시 201 Created 응답
+        // SEQ 6. 페이지네이션 COUNT 캐시 무효화 (탭별)
+        paginationCountCacheService.evict("repost:" + tabId);
+
+        // SEQ 7. 즉시 201 Created 응답
         return RepostDto.Response.of(repost);
     }
 
@@ -124,6 +129,9 @@ public class RepostService {
 
         // SEQ 3. Repost 삭제
         repostRepository.delete(repost);
+
+        // SEQ 4. 페이지네이션 COUNT 캐시 무효화 (해당 탭)
+        paginationCountCacheService.evict("repost:" + repost.getRepostTab().getId());
     }
 
     @Transactional
@@ -179,6 +187,9 @@ public class RepostService {
         // SEQ 3. 리포스트 탭 제거
         repostRepository.deleteAllByRepostTabId(tabId); // Bulk로 Repost 명시적 삭제 (성능을 위해)
         repostTabRepository.delete(tab);
+
+        // SEQ 4. 페이지네이션 COUNT 캐시 무효화
+        paginationCountCacheService.evict("repost:" + tabId);
     }
 
     @ExecutionTime

--- a/src/main/java/com/depth/deokive/domain/post/service/RepostService.java
+++ b/src/main/java/com/depth/deokive/domain/post/service/RepostService.java
@@ -2,6 +2,7 @@ package com.depth.deokive.domain.post.service;
 
 import com.depth.deokive.common.service.ArchiveGuard;
 import com.depth.deokive.common.service.PaginationCountCacheService;
+import com.depth.deokive.common.service.PaginationIdCacheService;
 import com.depth.deokive.common.util.PageUtils;
 import com.depth.deokive.common.util.TextUtils;
 import com.depth.deokive.domain.archive.entity.Archive;
@@ -46,6 +47,7 @@ public class RepostService {
 
     private final RepostOgProducer repostOgProducer;
     private final PaginationCountCacheService paginationCountCacheService;
+    private final PaginationIdCacheService paginationIdCacheService;
 
     /**
      * Repost 생성 - 비동기 OG 추출 (RabbitMQ)
@@ -97,8 +99,9 @@ public class RepostService {
         // SEQ 5. RabbitMQ 발행 (트랜잭션 커밋 후 실제 전송, SSE 알림용 userId 포함)
         repostOgProducer.requestOgExtraction(repost.getId(), userPrincipal.getUserId(), url);
 
-        // SEQ 6. 페이지네이션 COUNT 캐시 무효화 (탭별)
+        // SEQ 6. 페이지네이션 캐시 무효화 (탭별)
         paginationCountCacheService.evict("repost:" + tabId);
+        paginationIdCacheService.evictByPrefix("repost:" + tabId);
 
         // SEQ 7. 즉시 201 Created 응답
         return RepostDto.Response.of(repost);
@@ -130,8 +133,9 @@ public class RepostService {
         // SEQ 3. Repost 삭제
         repostRepository.delete(repost);
 
-        // SEQ 4. 페이지네이션 COUNT 캐시 무효화 (해당 탭)
+        // SEQ 4. 페이지네이션 캐시 무효화 (해당 탭)
         paginationCountCacheService.evict("repost:" + repost.getRepostTab().getId());
+        paginationIdCacheService.evictByPrefix("repost:" + repost.getRepostTab().getId());
     }
 
     @Transactional
@@ -188,8 +192,9 @@ public class RepostService {
         repostRepository.deleteAllByRepostTabId(tabId); // Bulk로 Repost 명시적 삭제 (성능을 위해)
         repostTabRepository.delete(tab);
 
-        // SEQ 4. 페이지네이션 COUNT 캐시 무효화
+        // SEQ 4. 페이지네이션 캐시 무효화
         paginationCountCacheService.evict("repost:" + tabId);
+        paginationIdCacheService.evictByPrefix("repost:" + tabId);
     }
 
     @ExecutionTime

--- a/src/main/java/com/depth/deokive/domain/ticket/repository/TicketQueryRepository.java
+++ b/src/main/java/com/depth/deokive/domain/ticket/repository/TicketQueryRepository.java
@@ -1,10 +1,10 @@
 package com.depth.deokive.domain.ticket.repository;
 
+import com.depth.deokive.common.service.PaginationCountCacheService;
 import com.depth.deokive.domain.ticket.dto.TicketDto;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -23,6 +23,7 @@ import static com.depth.deokive.domain.ticket.entity.QTicket.ticket;
 public class TicketQueryRepository {
 
     private final JPAQueryFactory queryFactory;
+    private final PaginationCountCacheService paginationCountCacheService;
 
     public Page<TicketDto.TicketPageResponse> searchTicketsByBook(Long ticketBookId, Pageable pageable) {
 
@@ -60,13 +61,16 @@ public class TicketQueryRepository {
                     .fetch();
         }
 
-        // SEQ 3. Count Query
-        JPAQuery<Long> countQuery = queryFactory
-                .select(ticket.count())
-                .from(ticket)
-                .where(ticket.ticketBook.id.eq(ticketBookId));
+        // SEQ 3. Count Query - Redis 캐싱
+        String countCacheKey = "ticket:" + ticketBookId;
 
-        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+        return PageableExecutionUtils.getPage(content, pageable,
+                () -> paginationCountCacheService.getCount(countCacheKey, () ->
+                        queryFactory.select(ticket.count())
+                                .from(ticket)
+                                .where(ticket.ticketBook.id.eq(ticketBookId))
+                                .fetchOne()
+                ));
     }
 
     private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {

--- a/src/main/java/com/depth/deokive/domain/ticket/repository/TicketQueryRepository.java
+++ b/src/main/java/com/depth/deokive/domain/ticket/repository/TicketQueryRepository.java
@@ -1,6 +1,7 @@
 package com.depth.deokive.domain.ticket.repository;
 
 import com.depth.deokive.common.service.PaginationCountCacheService;
+import com.depth.deokive.common.service.PaginationIdCacheService;
 import com.depth.deokive.domain.ticket.dto.TicketDto;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.depth.deokive.domain.ticket.entity.QTicket.ticket;
 
@@ -24,18 +26,28 @@ public class TicketQueryRepository {
 
     private final JPAQueryFactory queryFactory;
     private final PaginationCountCacheService paginationCountCacheService;
+    private final PaginationIdCacheService paginationIdCacheService;
 
     public Page<TicketDto.TicketPageResponse> searchTicketsByBook(Long ticketBookId, Pageable pageable) {
 
-        // SEQ 1. 커버링 인덱스 활용
-        List<Long> ids = queryFactory
-                .select(ticket.id)
-                .from(ticket)
-                .where(ticket.ticketBook.id.eq(ticketBookId))
-                .orderBy(getOrderSpecifiers(pageable))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+        // SEQ 1. 커버링 인덱스 활용 - Redis 캐싱
+        String sortKey = pageable.getSort().stream()
+                .map(o -> o.getProperty() + "_" + o.getDirection())
+                .collect(Collectors.joining(","));
+        String idsCacheKey = "ticket:" + ticketBookId
+                + ":" + (sortKey.isEmpty() ? "default" : sortKey)
+                + ":" + pageable.getPageNumber() + ":" + pageable.getPageSize();
+
+        List<Long> ids = paginationIdCacheService.getIds(idsCacheKey, () ->
+                queryFactory
+                        .select(ticket.id)
+                        .from(ticket)
+                        .where(ticket.ticketBook.id.eq(ticketBookId))
+                        .orderBy(getOrderSpecifiers(pageable))
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch()
+        );
 
         // SEQ 2. 데이터 조회
         List<TicketDto.TicketPageResponse> content = new ArrayList<>();

--- a/src/main/java/com/depth/deokive/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/depth/deokive/domain/ticket/service/TicketService.java
@@ -3,6 +3,7 @@ package com.depth.deokive.domain.ticket.service;
 import com.depth.deokive.common.dto.PageDto;
 import com.depth.deokive.common.service.ArchiveGuard;
 import com.depth.deokive.common.service.PaginationCountCacheService;
+import com.depth.deokive.common.service.PaginationIdCacheService;
 import com.depth.deokive.common.util.PageUtils;
 import com.depth.deokive.domain.file.entity.File;
 import com.depth.deokive.domain.file.service.FileService;
@@ -33,6 +34,7 @@ public class TicketService {
     private final FriendMapRepository friendMapRepository;
     private final TicketQueryRepository ticketQueryRepository;
     private final PaginationCountCacheService paginationCountCacheService;
+    private final PaginationIdCacheService paginationIdCacheService;
 
     @Transactional
     public TicketDto.Response createTicket(UserPrincipal userPrincipal, Long archiveId, TicketDto.CreateRequest request) {
@@ -52,6 +54,7 @@ public class TicketService {
         ticketRepository.save(ticket);
 
         paginationCountCacheService.evict("ticket:" + archiveId);
+        paginationIdCacheService.evictByPrefix("ticket:" + archiveId);
 
         return TicketDto.Response.of(ticket);
     }
@@ -112,6 +115,7 @@ public class TicketService {
         ticketRepository.delete(ticket);
 
         paginationCountCacheService.evict("ticket:" + ticket.getTicketBook().getId());
+        paginationIdCacheService.evictByPrefix("ticket:" + ticket.getTicketBook().getId());
     }
 
     @Transactional

--- a/src/main/java/com/depth/deokive/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/depth/deokive/domain/ticket/service/TicketService.java
@@ -2,6 +2,7 @@ package com.depth.deokive.domain.ticket.service;
 
 import com.depth.deokive.common.dto.PageDto;
 import com.depth.deokive.common.service.ArchiveGuard;
+import com.depth.deokive.common.service.PaginationCountCacheService;
 import com.depth.deokive.common.util.PageUtils;
 import com.depth.deokive.domain.file.entity.File;
 import com.depth.deokive.domain.file.service.FileService;
@@ -31,6 +32,7 @@ public class TicketService {
     private final TicketBookRepository ticketBookRepository;
     private final FriendMapRepository friendMapRepository;
     private final TicketQueryRepository ticketQueryRepository;
+    private final PaginationCountCacheService paginationCountCacheService;
 
     @Transactional
     public TicketDto.Response createTicket(UserPrincipal userPrincipal, Long archiveId, TicketDto.CreateRequest request) {
@@ -48,6 +50,8 @@ public class TicketService {
         // SEQ 3. 저장 (Entity에 File 바로 꽂기)
         Ticket ticket = request.toEntity(ticketBook, file);
         ticketRepository.save(ticket);
+
+        paginationCountCacheService.evict("ticket:" + archiveId);
 
         return TicketDto.Response.of(ticket);
     }
@@ -106,6 +110,8 @@ public class TicketService {
         archiveGuard.checkOwner(ticket.getTicketBook().getArchive().getUser().getId(), userPrincipal);
 
         ticketRepository.delete(ticket);
+
+        paginationCountCacheService.evict("ticket:" + ticket.getTicketBook().getId());
     }
 
     @Transactional


### PR DESCRIPTION
## 1️⃣. 작업 내용

1. Deep Pagination이 유저 한 명이 요청할 때는 괜찮은 응답을 반환하는데, 동시 유저 시 Pool이 남아나지를 않아서 전체 지연으로 이어짐 
2. 그래서 Caching을 했음. Deep Pagination에서 connection으로 오래 점유해도 나머지는 빠르게 돌아가고, 정상적인 시나리오에서는 80% 수준이 다 1~20 페이지 수준에서 노니까 문제가 안되리라 판단
3. 기존의 Like 기능 관련하여 자가 호출로 인한 Async 무시되는 현상 해결


## 2️⃣. 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 
> 테스트 시나리오 작성 페이지를 제공해주세요. 

## 3️⃣. 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 관련 이슈를 연결했나요? (Ex: #이슈번호)

## 4️⃣. 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## 5️⃣. 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요